### PR TITLE
Proposal to introduce “_id” and "reference" descriptions

### DIFF
--- a/main/VDA_231-301_Schema_Generic.json
+++ b/main/VDA_231-301_Schema_Generic.json
@@ -1288,7 +1288,7 @@
         },
         "ComponentMasterID": {
           "$ref": "#/$defs/Generic.Identifier",
-          "description": "A reference to the component master used. The _id of the component master should be used as the identifier."
+          "description": "Reference to the component master used, expressed as its transmission-scoped identifier (_id) within this transmission file."
         },
         "AdditionalInformation": {
           "$ref": "#/$defs/Generic.InformationSet"


### PR DESCRIPTION
This pull request introduces clearer schema documentation and a small typing fix:

- Added precise descriptions for the "_id" fields, clarifying that it is a transmission-scoped UUID used only for internal cross-referencing within the transmission file.
- Added/updated descriptions for all internal reference fields to explicitly state they must match the referenced object’s _id within the same transmission file.
- Fixed a minor type issue for one _id field by changing it from a restricted string to Generic.Identifier.