### PR TITLE
Proposal to use the TestingCenter-Reference

### DIFF
--- a/main/VDA_231-301_Schema_Generic.json
+++ b/main/VDA_231-301_Schema_Generic.json
@@ -1089,7 +1089,7 @@
           },
           "type": "array"
         },
-        "VatID": {
+        "VatId": {
           "$ref": "#/$defs/Generic.RestrictedString"
         }
       },


### PR DESCRIPTION
- Change “Contractor” and ‘TestingCenter’ in the existing schema from “Generic.TestingCenter” to “Generic.Identifier” to refer to them instead of specifying the data record.
- Introduction of the new TestingCenters to define all TestingCenters used in a central location in the schema.