### PR TITLE
Merge Feat/8 add geo data in location into main

### DIFF
--- a/main/VDA_231-301_Schema_Generic.json
+++ b/main/VDA_231-301_Schema_Generic.json
@@ -303,6 +303,9 @@
         },
         "AddressSimplifiedEnglish": {
           "$ref": "#/$defs/Generic.ContactDetailsSimplifiedEnglish"
+        },
+        "GeoData": {
+          "$ref": "#/$defs/Generic.GeoData"
         }
       },
       "required": [
@@ -311,6 +314,47 @@
         "Identification"
       ],
       "type": "object"
+    },
+    "Generic.GeoData": {
+      "type": "FeatureCollection",
+      "features": {
+        "type": "array",
+        "items": {
+          "$ref": "#/$defs/Generic.GeoJSONFeature"
+        }
+      },
+      "required": [
+        "features"
+      ]
+    },
+    "Generic.GeoJSONFeature": {
+      "type": "Feature",
+      "geometry": {
+        "type": "string",
+        "enum": [
+          "Point",
+          "LineString",
+          "Polygon",
+          "MultiPoint",
+          "MultiLineString",
+          "MultiPolygon"
+        ],
+        "coordinates": {
+          "description": "A position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or easting and northing, precisely in that order and using decimal numbers.",
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "type": "number"
+          }
+        }
+      },
+      "properties": {
+        "type": "object"
+      },
+      "required": [
+        "geometry"
+      ]
     },
     "Generic.CharacteristicValues": {
       "anyOf": [

--- a/main/VDA_231-301_Schema_Generic.json
+++ b/main/VDA_231-301_Schema_Generic.json
@@ -305,7 +305,8 @@
           "$ref": "#/$defs/Generic.ContactDetailsSimplifiedEnglish"
         },
         "GeoData": {
-          "$ref": "#/$defs/Generic.GeoData"
+          "$ref": "#/$defs/Generic.GeoData",
+          "description": "GeoJSON data describing the location of facilities such as testing laboratories or production sites. When sharing geospatial data, data providers should consider whether the precision of the coordinates is appropriate for the intended use case. Highly precise locations of laboratories, machinery, or other sensitive infrastructure may constitute sensitive geodata (see IMAGI guidance on sensitive geodata - https://imagi.de/). Data providers and receiving contractual partners are responsible for ensuring appropriate protection and secure handling of the shared data."
         }
       },
       "required": [
@@ -316,44 +317,72 @@
       "type": "object"
     },
     "Generic.GeoData": {
-      "type": "FeatureCollection",
-      "features": {
-        "type": "array",
-        "items": {
-          "$ref": "#/$defs/Generic.GeoJSONFeature"
+      "additionalProperties": false,
+      "description": "A GeoJSON FeatureCollection object as defined in RFC 7946.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "FeatureCollection",
+          "type": "string"
+        },
+        "features": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Generic.GeoJSONFeature"
+          }
         }
       },
       "required": [
+        "type",
         "features"
       ]
     },
     "Generic.GeoJSONFeature": {
-      "type": "Feature",
-      "geometry": {
-        "type": "string",
-        "enum": [
-          "Point",
-          "LineString",
-          "Polygon",
-          "MultiPoint",
-          "MultiLineString",
-          "MultiPolygon"
-        ],
-        "coordinates": {
-          "description": "A position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or easting and northing, precisely in that order and using decimal numbers.",
-          "type": "array",
-          "minItems": 2,
-          "maxItems": 2,
-          "items": {
-            "type": "number"
-          }
+      "additionalProperties": false,
+      "description": "A GeoJSON Feature object as defined in RFC 7946.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "Feature",
+          "type": "string"
+        },
+        "geometry": {
+          "$ref": "#/$defs/Generic.GeoJSONGeometry"
+        },
+        "properties": {
+          "type": "object"
         }
       },
+      "required": [
+        "type",
+        "geometry"
+      ]
+    },
+    "Generic.GeoJSONGeometry": {
+      "additionalProperties": false,
+      "description": "A GeoJSON Geometry object as defined in RFC 7946.",
+      "type": "object",
       "properties": {
-        "type": "object"
+        "type": {
+          "type": "string",
+          "enum": [
+            "Point",
+            "LineString",
+            "Polygon",
+            "MultiPoint",
+            "MultiLineString",
+            "MultiPolygon"
+          ]
+        },
+        "coordinates": {
+          "description": "A position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or easting and northing, precisely in that order and using decimal numbers. The structure varies by geometry type.",
+          "type": "array",
+          "minItems": 2
+        }
       },
       "required": [
-        "geometry"
+        "type",
+        "coordinates"
       ]
     },
     "Generic.CharacteristicValues": {

--- a/main/examples/VDA_231-301_SpecificationCustomization.example.json
+++ b/main/examples/VDA_231-301_SpecificationCustomization.example.json
@@ -253,7 +253,19 @@
             "Type": "DUNS"
           }
         ],
-        "Name": "Materialprüfanstalt Stuttgart"
+        "Name": "Materialprüfanstalt Stuttgart",
+        "GeoData": {
+          "type": "FeatureCollection",
+          "features": [
+            {
+              "type": "Feature",
+              "geometry": {
+                "type": "Point",
+                "coordinates": [10.960222, 49.455973]
+              }
+            }
+          ]
+        }
       },
       "TestingManager": {
         "_id": "b0c1d2e3-f4a5-4b6c-8d7e-000000000003",


### PR DESCRIPTION
## Summary

This pull-request merges the change of the branch 'Feat/8 add geo data in location' into the 'main' branch.

---

## Type of Change

- [ ] Documentation / editorial change
- [ ] Clarification or correction
- [ ] Subschema schema change
- [x] Example or sample data update
- [x] Proposal / preparatory work
- [ ] Other

---

## Motivation and Context

Adding GeoData to the Location to have more visibility about the location.

---

## Description of Changes

A GeoData property was added to the definition of the location. GeoData itself was defined accordingly  to the GeoJSON format: https://datatracker.ietf.org/doc/html/rfc7946#section-3

---

## Impact and Compatibility

As the GeoData point is optional, it does not require any changes to other related subschemas or examples.

---

## Checklist

- [x] I have checked existing issues and pull requests to avoid duplicates.
- [x] This change is within the scope of this repository.
- [x] This pull request does not claim to constitute an official VDA release or approval.
- [x] I understand that acceptance on GitHub does not replace the formal VDA review and release process.
