### PR TITLE
Add designation, sub-components and NGIDPath to ComponentMaster

### DIFF
--- a/assets/ERM/ERM_EntitiesOnly_EN.graphml
+++ b/assets/ERM/ERM_EntitiesOnly_EN.graphml
@@ -1356,10 +1356,57 @@
       </data>
     </edge>
     <edge id="e39" source="n57" target="n56">
+      <data key="d9">
+        <y:PolyLineEdge>
+          <y:Path sx="0.0" sy="0.0" tx="0.0" ty="0.0"/>
+          <y:LineStyle color="#000000" type="line" width="1.0"/>
+          <y:Arrows source="crows_foot_many_optional" target="none"/>
+          <y:BendStyle smoothed="false"/>
+        </y:PolyLineEdge>
+      </data>
+    </edge>
+    <edge id="e40" source="n1" target="n48">
+      <data key="d8"/>
+      <data key="d9">
+        <y:PolyLineEdge>
+          <y:Path sx="-264.8204044425951" sy="-382.20309162134606" tx="-55.543969458602646" ty="9.098489425981626">
+            <y:Point x="560.7680218251683" y="89.52000000000018"/>
+          </y:Path>
+          <y:LineStyle color="#000000" type="line" width="1.0"/>
+          <y:Arrows source="crows_foot_many_optional" target="none"/>
+          <y:BendStyle smoothed="false"/>
+        </y:PolyLineEdge>
+      </data>
+    </edge>
+    <edge id="e41" source="n48" target="n1">
       <data key="d8"/>
       <data key="d9">
         <y:PolyLineEdge>
           <y:Path sx="0.0" sy="0.0" tx="0.0" ty="0.0"/>
+          <y:LineStyle color="#000000" type="line" width="1.0"/>
+          <y:Arrows source="crows_foot_many_optional" target="none"/>
+          <y:BendStyle smoothed="false"/>
+        </y:PolyLineEdge>
+      </data>
+    </edge>
+    <edge id="e42" source="n48" target="n1">
+      <data key="d8"/>
+      <data key="d9">
+        <y:PolyLineEdge>
+          <y:Path sx="0.0" sy="0.0" tx="0.0" ty="0.0"/>
+          <y:LineStyle color="#000000" type="line" width="1.0"/>
+          <y:Arrows source="crows_foot_many_optional" target="none"/>
+          <y:BendStyle smoothed="false"/>
+        </y:PolyLineEdge>
+      </data>
+    </edge>
+    <edge id="e43" source="n48" target="n48">
+      <data key="d8"/>
+      <data key="d9">
+        <y:PolyLineEdge>
+          <y:Path sx="38.41241322014855" sy="0.0" tx="50.15696105499251" ty="0.0">
+            <y:Point x="679.0523964475246" y="139.52000000000018"/>
+          </y:Path>
           <y:LineStyle color="#000000" type="line" width="1.0"/>
           <y:Arrows source="crows_foot_many_optional" target="none"/>
           <y:BendStyle smoothed="false"/>

--- a/assets/ERM/ERM_EntitiesOnly_EN.svg
+++ b/assets/ERM/ERM_EntitiesOnly_EN.svg
@@ -327,24 +327,30 @@
         <path d="M555.903 -1032.1896 L555.903 270.8104 L-1081.097 270.8104 L-1081.097 -1032.1896 L555.903 -1032.1896 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath38">
-        <path d="M-567.5103 431.768 L-567.5103 -871.232 L1069.4897 -871.232 L1069.4897 431.768 L-567.5103 431.768 Z"/>
+        <path d="M771.1779 -19.2665 L-6.1442 1026.4769 L-1319.9447 49.9027 L-542.6226 -995.8407 L771.1779 -19.2665 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath39">
-        <path d="M-692.8198 431.768 L-692.8198 -871.232 L944.1802 -871.232 L944.1802 431.768 L-692.8198 431.768 Z"/>
+        <path d="M0 10 L0 -10 L-12 -10 L-12 10 L0 10 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath40">
-        <path d="M-330.2318 -1452.1047 L972.7682 -1452.1047 L972.7682 184.8952 L-330.2318 184.8952 L-330.2318 -1452.1047 Z"/>
+        <path d="M-567.5103 431.768 L-567.5103 -871.232 L1069.4897 -871.232 L1069.4897 431.768 L-567.5103 431.768 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath41">
-        <path d="M-1501.4502 202.9054 L-1501.4502 -1100.0946 L135.5498 -1100.0946 L135.5498 202.9054 L-1501.4502 202.9054 Z"/>
+        <path d="M-692.8198 431.768 L-692.8198 -871.232 L944.1802 -871.232 L944.1802 431.768 L-692.8198 431.768 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath42">
-        <path d="M-735.2026 -1452.1047 L567.7974 -1452.1047 L567.7974 184.8952 L-735.2026 184.8952 L-735.2026 -1452.1047 Z"/>
+        <path d="M-330.2318 -1452.1047 L972.7682 -1452.1047 L972.7682 184.8952 L-330.2318 184.8952 L-330.2318 -1452.1047 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath43">
-        <path d="M-1501.4502 607.8762 L-1501.4502 -695.1238 L135.5498 -695.1238 L135.5498 607.8762 L-1501.4502 607.8762 Z"/>
+        <path d="M-1501.4502 202.9054 L-1501.4502 -1100.0946 L135.5498 -1100.0946 L135.5498 202.9054 L-1501.4502 202.9054 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath44">
+        <path d="M-735.2026 -1452.1047 L567.7974 -1452.1047 L567.7974 184.8952 L-735.2026 184.8952 L-735.2026 -1452.1047 Z"/>
+      </clipPath>
+      <clipPath clipPathUnits="userSpaceOnUse" id="clipPath45">
+        <path d="M-1501.4502 607.8762 L-1501.4502 -695.1238 L135.5498 -695.1238 L135.5498 607.8762 L-1501.4502 607.8762 Z"/>
+      </clipPath>
+      <clipPath clipPathUnits="userSpaceOnUse" id="clipPath46">
         <path d="M-1293.1809 398.5823 L-1293.1809 -904.4177 L343.8192 -904.4177 L343.8192 398.5823 L-1293.1809 398.5823 Z"/>
       </clipPath>
     </defs>
@@ -981,47 +987,55 @@
       <path fill="none" d="M1161.1896 69.2056 L1161.1896 28.4657 L526.2664 28.4657 L526.2664 111.5045" clip-path="url(#clipPath2)"/>
       <path d="M526.2664 119.5045 L531.2664 107.5045 L526.2664 110.5045 L521.2664 107.5045 Z" clip-path="url(#clipPath2)" stroke="none"/>
       <text x="550.9662" y="43.4756" clip-path="url(#clipPath2)" font-family="sans-serif" stroke-dasharray="none" stroke="none" xml:space="preserve">via ID</text>
-      <path fill="none" stroke-dasharray="none" d="M560.768 110.5102 L560.768 65.1391 L707.4595 65.1391" clip-path="url(#clipPath2)" stroke="black"/>
-      <line transform="matrix(0,1,-1,0,560.768,119.5102)" clip-path="url(#clipPath38)" fill="none" x1="-15" x2="-15" y1="-8" y2="8" stroke-dasharray="none" stroke="black"/>
-      <line transform="matrix(0,1,-1,0,560.768,119.5102)" clip-path="url(#clipPath6)" fill="none" x1="-10" x2="2" y1="0" y2="8" stroke-dasharray="none" stroke="black"/>
-      <line transform="matrix(0,1,-1,0,560.768,119.5102)" clip-path="url(#clipPath6)" fill="none" x1="-10" x2="2" y1="0" y2="0" stroke-dasharray="none" stroke="black"/>
-      <line transform="matrix(0,1,-1,0,560.768,119.5102)" clip-path="url(#clipPath6)" fill="none" x1="-10" x2="2" y1="0" y2="-8" stroke-dasharray="none" stroke="black"/>
+      <path fill="none" stroke-dasharray="none" d="M609.8882 166.6505 L609.9448 166.733 L610.8774 167.759 L613.7134 170.3365 L616.7878 172.6355 L620.0806 174.6359 L623.5715 176.3176 L627.2407 177.6605 L631.0679 178.6446 L635.0332 179.2498 L639.1164 179.456 L643.1996 179.2498 L647.1649 178.6446 L650.9921 177.6605 L654.6613 176.3176 L658.1523 174.6359 L661.445 172.6355 L664.5194 170.3365 L667.3554 167.759 L669.9329 164.923 L672.2319 161.8486 L674.2323 158.5559 L675.914 155.0649 L677.257 151.3957 L678.241 147.5685 L678.8462 143.6032 L679.0524 139.52 L678.8462 135.4368 L678.241 131.4715 L677.257 127.6443 L675.914 123.9751 L674.2323 120.4841 L672.2319 117.1914 L669.9329 114.117 L667.3554 111.281 L664.5194 108.7035 L661.445 106.4045 L658.1523 104.4041 L654.6613 102.7224 L650.9921 101.3795 L647.1649 100.3954 L643.1996 99.7902 L639.1164 99.584 L635.0332 99.7902 L631.0679 100.3954 L627.2407 101.3795 L623.5715 102.7224 L620.0806 104.4041 L616.7878 106.4045 L613.7134 108.7035 L610.8774 111.281 L608.2999 114.117 L606.0009 117.1914 L604.5787 119.5323" clip-path="url(#clipPath2)" stroke="black"/>
+      <circle transform="matrix(-0.5966,-0.8026,0.8026,-0.5966,604.5191,159.4274)" clip-path="url(#clipPath38)" fill="white" r="5" stroke-dasharray="none" cx="-15" cy="0" stroke="none"/>
+      <circle transform="matrix(-0.5966,-0.8026,0.8026,-0.5966,604.5191,159.4274)" clip-path="url(#clipPath38)" fill="none" r="5" stroke-dasharray="none" cx="-15" cy="0" stroke="black"/>
+      <line transform="matrix(-0.5966,-0.8026,0.8026,-0.5966,604.5191,159.4274)" clip-path="url(#clipPath39)" fill="none" x1="-10" x2="2" y1="0" y2="8" stroke-dasharray="none" stroke="black"/>
+      <line transform="matrix(-0.5966,-0.8026,0.8026,-0.5966,604.5191,159.4274)" clip-path="url(#clipPath39)" fill="none" x1="-10" x2="2" y1="0" y2="0" stroke-dasharray="none" stroke="black"/>
+      <line transform="matrix(-0.5966,-0.8026,0.8026,-0.5966,604.5191,159.4274)" clip-path="url(#clipPath39)" fill="none" x1="-10" x2="2" y1="0" y2="-8" stroke-dasharray="none" stroke="black"/>
+    </g>
+    <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-129,448)" stroke-linecap="butt">
+      <path fill="none" d="M560.768 110.5102 L560.768 65.1391 L707.4595 65.1391" clip-path="url(#clipPath2)"/>
+      <line transform="matrix(0,1,-1,0,560.768,119.5102)" clip-path="url(#clipPath40)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
+      <line transform="matrix(0,1,-1,0,560.768,119.5102)" clip-path="url(#clipPath6)" fill="none" x1="-10" x2="2" y1="0" y2="8"/>
+      <line transform="matrix(0,1,-1,0,560.768,119.5102)" clip-path="url(#clipPath6)" fill="none" x1="-10" x2="2" y1="0" y2="0"/>
+      <line transform="matrix(0,1,-1,0,560.768,119.5102)" clip-path="url(#clipPath6)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-129,448)" stroke-linecap="butt">
       <path fill="none" d="M560.768 159.4919 L560.768 235.8198" clip-path="url(#clipPath2)"/>
-      <line transform="matrix(0,1,-1,0,560.768,244.8198)" clip-path="url(#clipPath39)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
+      <line transform="matrix(0,1,-1,0,560.768,244.8198)" clip-path="url(#clipPath41)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
       <line transform="matrix(0,1,-1,0,560.768,244.8198)" clip-path="url(#clipPath6)" fill="none" x1="-10" x2="2" y1="0" y2="8"/>
       <line transform="matrix(0,1,-1,0,560.768,244.8198)" clip-path="url(#clipPath6)" fill="none" x1="-10" x2="2" y1="0" y2="0"/>
       <line transform="matrix(0,1,-1,0,560.768,244.8198)" clip-path="url(#clipPath6)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-129,448)" stroke-linecap="butt">
       <path fill="none" d="M400.2681 1004.1048 L459.2318 1004.1048" clip-path="url(#clipPath2)"/>
-      <line transform="matrix(1,0,0,1,459.2318,1004.1048)" clip-path="url(#clipPath40)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
-      <line transform="matrix(1,0,0,1,459.2318,1004.1048)" clip-path="url(#clipPath40)" fill="none" x1="-6" x2="-6" y1="-8" y2="8"/>
+      <line transform="matrix(1,0,0,1,459.2318,1004.1048)" clip-path="url(#clipPath42)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
+      <line transform="matrix(1,0,0,1,459.2318,1004.1048)" clip-path="url(#clipPath42)" fill="none" x1="-6" x2="-6" y1="-8" y2="8"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-129,448)" stroke-linecap="butt">
       <path fill="none" d="M331.9054 1044.4502 L331.9054 1023.4285" clip-path="url(#clipPath2)"/>
-      <line transform="matrix(0,1,-1,0,331.9054,1053.4502)" clip-path="url(#clipPath41)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
+      <line transform="matrix(0,1,-1,0,331.9054,1053.4502)" clip-path="url(#clipPath43)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
       <line transform="matrix(0,1,-1,0,331.9054,1053.4502)" clip-path="url(#clipPath6)" fill="none" x1="-10" x2="2" y1="0" y2="8"/>
       <line transform="matrix(0,1,-1,0,331.9054,1053.4502)" clip-path="url(#clipPath6)" fill="none" x1="-10" x2="2" y1="0" y2="0"/>
       <line transform="matrix(0,1,-1,0,331.9054,1053.4502)" clip-path="url(#clipPath6)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-129,448)" stroke-linecap="butt">
       <path fill="none" d="M805.239 1004.1048 L864.2026 1004.1048" clip-path="url(#clipPath2)"/>
-      <line transform="matrix(1,0,0,1,864.2026,1004.1048)" clip-path="url(#clipPath42)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
-      <line transform="matrix(1,0,0,1,864.2026,1004.1048)" clip-path="url(#clipPath42)" fill="none" x1="-6" x2="-6" y1="-8" y2="8"/>
+      <line transform="matrix(1,0,0,1,864.2026,1004.1048)" clip-path="url(#clipPath44)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
+      <line transform="matrix(1,0,0,1,864.2026,1004.1048)" clip-path="url(#clipPath44)" fill="none" x1="-6" x2="-6" y1="-8" y2="8"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-129,448)" stroke-linecap="butt">
       <path fill="none" d="M736.8762 1044.4502 L736.8762 1023.4285" clip-path="url(#clipPath2)"/>
-      <line transform="matrix(0,1,-1,0,736.8762,1053.4502)" clip-path="url(#clipPath43)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
+      <line transform="matrix(0,1,-1,0,736.8762,1053.4502)" clip-path="url(#clipPath45)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
       <line transform="matrix(0,1,-1,0,736.8762,1053.4502)" clip-path="url(#clipPath6)" fill="none" x1="-10" x2="2" y1="0" y2="8"/>
       <line transform="matrix(0,1,-1,0,736.8762,1053.4502)" clip-path="url(#clipPath6)" fill="none" x1="-10" x2="2" y1="0" y2="0"/>
       <line transform="matrix(0,1,-1,0,736.8762,1053.4502)" clip-path="url(#clipPath6)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-129,448)" stroke-linecap="butt">
       <path fill="none" d="M527.5823 836.1808 L527.5823 815.8383" clip-path="url(#clipPath2)"/>
-      <circle transform="matrix(0,1,-1,0,527.5823,845.1808)" clip-path="url(#clipPath44)" fill="white" r="5" cx="-15" cy="0" stroke="none"/>
-      <circle fill="none" r="5" clip-path="url(#clipPath44)" cx="-15" transform="matrix(0,1,-1,0,527.5823,845.1808)" cy="0"/>
+      <circle transform="matrix(0,1,-1,0,527.5823,845.1808)" clip-path="url(#clipPath46)" fill="white" r="5" cx="-15" cy="0" stroke="none"/>
+      <circle fill="none" r="5" clip-path="url(#clipPath46)" cx="-15" transform="matrix(0,1,-1,0,527.5823,845.1808)" cy="0"/>
       <line transform="matrix(0,1,-1,0,527.5823,845.1808)" clip-path="url(#clipPath22)" fill="none" x1="-10" x2="2" y1="0" y2="8"/>
       <line transform="matrix(0,1,-1,0,527.5823,845.1808)" clip-path="url(#clipPath22)" fill="none" x1="-10" x2="2" y1="0" y2="0"/>
       <line transform="matrix(0,1,-1,0,527.5823,845.1808)" clip-path="url(#clipPath22)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>

--- a/assets/ERM/ERM_EntitiesWithAttributes_EN.graphml
+++ b/assets/ERM/ERM_EntitiesWithAttributes_EN.graphml
@@ -808,7 +808,7 @@ Phone*<y:LabelModel><y:ErdAttributesNodeLabelModel/></y:LabelModel><y:ModelParam
     <node id="n44">
       <data key="d5">
         <y:GenericNode configuration="com.yworks.entityRelationship.big_entity">
-          <y:Geometry height="217.162124094" width="250.7890625" x="244.001591658231" y="368.39998080216276"/>
+          <y:Geometry height="217.162124094" width="250.7890625" x="244.001591658231" y="402.5159896641969"/>
           <y:Fill color="#FFFFFF" transparent="false"/>
           <y:BorderStyle color="#000000" type="line" width="1.0"/>
           <y:NodeLabel alignment="center" autoSizePolicy="content" backgroundColor="#EDEDED" configuration="com.yworks.entityRelationship.label.name" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasLineColor="false" height="18.701171875" horizontalTextPosition="center" iconTextGap="4" modelName="internal" modelPosition="t" textColor="#000000" verticalTextPosition="bottom" visible="true" width="111.40234375" x="69.693359375" xml:space="preserve" y="4.0">ComponentInstance</y:NodeLabel>
@@ -833,11 +833,12 @@ BusinessKeys [BusinessKey]<y:LabelModel><y:ErdAttributesNodeLabelModel/></y:Labe
     <node id="n45">
       <data key="d5">
         <y:GenericNode configuration="com.yworks.entityRelationship.big_entity">
-          <y:Geometry height="304.30645796362035" width="322.550322520141" x="208.12096164816052" y="28.457735565066315"/>
+          <y:Geometry height="312.0234375" width="322.550322520141" x="208.12096164816046" y="24.599245796876488"/>
           <y:Fill color="#FFFFFF" transparent="false"/>
           <y:BorderStyle color="#000000" type="line" width="1.0"/>
           <y:NodeLabel alignment="center" autoSizePolicy="content" backgroundColor="#EDEDED" configuration="com.yworks.entityRelationship.label.name" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasLineColor="false" height="18.701171875" horizontalTextPosition="center" iconTextGap="4" modelName="internal" modelPosition="t" textColor="#000000" verticalTextPosition="bottom" visible="true" width="102.712890625" x="109.91871594757049" xml:space="preserve" y="4.0">ComponentMaster</y:NodeLabel>
-          <y:NodeLabel alignment="left" autoSizePolicy="content" configuration="com.yworks.entityRelationship.label.attributes" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="268.62109375" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="top" visible="true" width="314.142578125" x="2.0" xml:space="preserve" y="30.701171875">ID*
+          <y:NodeLabel alignment="left" autoSizePolicy="content" configuration="com.yworks.entityRelationship.label.attributes" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="283.322265625" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="top" visible="true" width="314.142578125" x="2.0" xml:space="preserve" y="30.701171875">ID*
+Designation
 CustomerPartNumber
 SupplierPartNumber
 Color
@@ -1085,7 +1086,7 @@ DeviatingValue [InformationPoint]<y:LabelModel><y:ErdAttributesNodeLabelModel/><
     <edge id="e0" source="n45" target="n3">
       <data key="d9">
         <y:PolyLineEdge>
-          <y:Path sx="1.588321103381624" sy="20.52799410539609" tx="-9.548053560793846" ty="45.1210720048181"/>
+          <y:Path sx="50.601461974105916" sy="-87.18271779686695" tx="-102.76892441746247" ty="-62.58963989744494"/>
           <y:LineStyle color="#000000" type="line" width="1.0"/>
           <y:Arrows source="crows_foot_many_mandatory" target="none"/>
           <y:BendStyle smoothed="false"/>
@@ -1229,7 +1230,7 @@ DeviatingValue [InformationPoint]<y:LabelModel><y:ErdAttributesNodeLabelModel/><
           </y:Path>
           <y:LineStyle color="#999999" type="dashed" width="1.0"/>
           <y:Arrows source="none" target="standard"/>
-          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="18.701171875" horizontalTextPosition="center" iconTextGap="4" modelName="custom" preferredPlacement="anywhere" ratio="0.5" textColor="#808080" verticalTextPosition="bottom" visible="true" width="34.673828125" x="-66.015164063275" xml:space="preserve" y="-158.17524280205396">via ID<y:LabelModel><y:SmartEdgeLabelModel autoRotationEnabled="false" defaultAngle="0.0" defaultDistance="10.0"/></y:LabelModel><y:ModelParameter><y:SmartEdgeLabelModelParameter angle="0.0" distance="18.606291153494002" distanceToCenter="true" position="right" ratio="0.4672446735436765" segment="-1"/></y:ModelParameter><y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" frozen="true" placement="anywhere" side="anywhere" sideReference="relative_to_edge_flow"/></y:EdgeLabel>
+          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="18.701171875" horizontalTextPosition="center" iconTextGap="4" modelName="custom" preferredPlacement="anywhere" ratio="0.5" textColor="#808080" verticalTextPosition="bottom" visible="true" width="34.673828125" x="-66.015164063275" xml:space="preserve" y="-142.23471937869954">via ID<y:LabelModel><y:SmartEdgeLabelModel autoRotationEnabled="false" defaultAngle="0.0" defaultDistance="10.0"/></y:LabelModel><y:ModelParameter><y:SmartEdgeLabelModelParameter angle="0.0" distance="18.606291153494002" distanceToCenter="true" position="right" ratio="0.4672446735436765" segment="-1"/></y:ModelParameter><y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" frozen="true" placement="anywhere" side="anywhere" sideReference="relative_to_edge_flow"/></y:EdgeLabel>
           <y:BendStyle smoothed="false"/>
         </y:PolyLineEdge>
       </data>
@@ -1506,9 +1507,9 @@ DeviatingValue [InformationPoint]<y:LabelModel><y:ErdAttributesNodeLabelModel/><
     <edge id="e36" source="n5" target="n45">
       <data key="d9">
         <y:PolyLineEdge>
-          <y:Path sx="0.0" sy="0.0" tx="150.71309698705497" ty="94.50465230695139">
+          <y:Path sx="0.0" sy="0.0" tx="150.30271616528364" ty="136.21378892841054">
             <y:Point x="588.7217473094368" y="410.5701837937613"/>
-            <y:Point x="588.7217473094368" y="275.1156168538279"/>
+            <y:Point x="588.7217473094368" y="316.824753475287"/>
           </y:Path>
           <y:LineStyle color="#999999" type="dashed" width="1.0"/>
           <y:Arrows source="none" target="standard"/>
@@ -1618,7 +1619,6 @@ DeviatingValue [InformationPoint]<y:LabelModel><y:ErdAttributesNodeLabelModel/><
       </data>
     </edge>
     <edge id="e47" source="n56" target="n2">
-      <data key="d8"/>
       <data key="d9">
         <y:PolyLineEdge>
           <y:Path sx="0.0" sy="0.0" tx="0.0" ty="0.0"/>
@@ -1629,12 +1629,25 @@ DeviatingValue [InformationPoint]<y:LabelModel><y:ErdAttributesNodeLabelModel/><
       </data>
     </edge>
     <edge id="e48" source="n57" target="n56">
-      <data key="d8"/>
       <data key="d9">
         <y:PolyLineEdge>
           <y:Path sx="0.0" sy="0.0" tx="0.0" ty="0.0"/>
           <y:LineStyle color="#000000" type="line" width="1.0"/>
           <y:Arrows source="crows_foot_many_optional" target="none"/>
+          <y:BendStyle smoothed="false"/>
+        </y:PolyLineEdge>
+      </data>
+    </edge>
+    <edge id="e49" source="n45" target="n45">
+      <data key="d8"/>
+      <data key="d9">
+        <y:PolyLineEdge>
+          <y:Path sx="124.42160599408521" sy="27.98369184885368" tx="88.99961815537489" ty="15.811005486404838">
+            <y:Point x="566.6572389767105" y="208.59465639573017"/>
+          </y:Path>
+          <y:LineStyle color="#000000" type="line" width="1.0"/>
+          <y:Arrows source="crows_foot_many_optional" target="none"/>
+          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="18.701171875" horizontalTextPosition="center" iconTextGap="4" modelName="custom" preferredPlacement="anywhere" ratio="0.5" textColor="#000000" verticalTextPosition="bottom" visible="true" width="93.390625" x="4.131930056233841" xml:space="preserve" y="3.137114820230863">SubComponents<y:LabelModel><y:SmartEdgeLabelModel autoRotationEnabled="false" defaultAngle="0.0" defaultDistance="10.0"/></y:LabelModel><y:ModelParameter><y:SmartEdgeLabelModelParameter angle="6.283185307179586" distance="32.411269642825744" distanceToCenter="false" position="left" ratio="-20.21303304511612" segment="-1"/></y:ModelParameter><y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" frozen="true" placement="anywhere" side="anywhere" sideReference="relative_to_edge_flow"/></y:EdgeLabel>
           <y:BendStyle smoothed="false"/>
         </y:PolyLineEdge>
       </data>

--- a/assets/ERM/ERM_EntitiesWithAttributes_EN.graphml
+++ b/assets/ERM/ERM_EntitiesWithAttributes_EN.graphml
@@ -833,11 +833,11 @@ BusinessKeys [BusinessKey]<y:LabelModel><y:ErdAttributesNodeLabelModel/></y:Labe
     <node id="n45">
       <data key="d5">
         <y:GenericNode configuration="com.yworks.entityRelationship.big_entity">
-          <y:Geometry height="312.0234375" width="322.550322520141" x="208.12096164816046" y="24.599245796876488"/>
+          <y:Geometry height="326.724609375" width="322.550322520141" x="208.12096164816046" y="17.248659859376488"/>
           <y:Fill color="#FFFFFF" transparent="false"/>
           <y:BorderStyle color="#000000" type="line" width="1.0"/>
           <y:NodeLabel alignment="center" autoSizePolicy="content" backgroundColor="#EDEDED" configuration="com.yworks.entityRelationship.label.name" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasLineColor="false" height="18.701171875" horizontalTextPosition="center" iconTextGap="4" modelName="internal" modelPosition="t" textColor="#000000" verticalTextPosition="bottom" visible="true" width="102.712890625" x="109.91871594757049" xml:space="preserve" y="4.0">ComponentMaster</y:NodeLabel>
-          <y:NodeLabel alignment="left" autoSizePolicy="content" configuration="com.yworks.entityRelationship.label.attributes" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="283.322265625" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="top" visible="true" width="314.142578125" x="2.0" xml:space="preserve" y="30.701171875">ID*
+          <y:NodeLabel alignment="left" autoSizePolicy="content" configuration="com.yworks.entityRelationship.label.attributes" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="298.0234375" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="top" visible="true" width="314.142578125" x="2.0" xml:space="preserve" y="30.701171875">ID*
 Designation
 CustomerPartNumber
 SupplierPartNumber
@@ -856,6 +856,7 @@ Comment
 BusinessKeys [BusinessKey]
 Mass [Mass]
 NumberOfParts
+NGIDPath
 <y:LabelModel><y:ErdAttributesNodeLabelModel/></y:LabelModel><y:ModelParameter><y:ErdAttributesNodeLabelModelParameter/></y:ModelParameter></y:NodeLabel>
           <y:StyleProperties>
             <y:Property class="java.lang.Boolean" name="y.view.ShadowNodePainter.SHADOW_PAINTING" value="true"/>
@@ -1086,7 +1087,7 @@ DeviatingValue [InformationPoint]<y:LabelModel><y:ErdAttributesNodeLabelModel/><
     <edge id="e0" source="n45" target="n3">
       <data key="d9">
         <y:PolyLineEdge>
-          <y:Path sx="50.601461974105916" sy="-87.18271779686695" tx="-102.76892441746247" ty="-62.58963989744494"/>
+          <y:Path sx="110.60646298179972" sy="-87.18271779686695" tx="-102.76892441746247" ty="-62.58963989744494"/>
           <y:LineStyle color="#000000" type="line" width="1.0"/>
           <y:Arrows source="crows_foot_many_mandatory" target="none"/>
           <y:BendStyle smoothed="false"/>
@@ -1507,9 +1508,9 @@ DeviatingValue [InformationPoint]<y:LabelModel><y:ErdAttributesNodeLabelModel/><
     <edge id="e36" source="n5" target="n45">
       <data key="d9">
         <y:PolyLineEdge>
-          <y:Path sx="0.0" sy="0.0" tx="150.30271616528364" ty="136.21378892841054">
+          <y:Path sx="0.0" sy="0.0" tx="150.30271616528364" ty="142.63158349803012">
             <y:Point x="588.7217473094368" y="410.5701837937613"/>
-            <y:Point x="588.7217473094368" y="316.824753475287"/>
+            <y:Point x="588.7217473094368" y="323.2425480449066"/>
           </y:Path>
           <y:LineStyle color="#999999" type="dashed" width="1.0"/>
           <y:Arrows source="none" target="standard"/>
@@ -1639,15 +1640,14 @@ DeviatingValue [InformationPoint]<y:LabelModel><y:ErdAttributesNodeLabelModel/><
       </data>
     </edge>
     <edge id="e49" source="n45" target="n45">
-      <data key="d8"/>
       <data key="d9">
         <y:PolyLineEdge>
-          <y:Path sx="124.42160599408521" sy="27.98369184885368" tx="88.99961815537489" ty="15.811005486404838">
+          <y:Path sx="124.42160599408521" sy="29.30216031668163" tx="88.99961815537489" ty="16.555950516927442">
             <y:Point x="566.6572389767105" y="208.59465639573017"/>
           </y:Path>
           <y:LineStyle color="#000000" type="line" width="1.0"/>
           <y:Arrows source="crows_foot_many_optional" target="none"/>
-          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="18.701171875" horizontalTextPosition="center" iconTextGap="4" modelName="custom" preferredPlacement="anywhere" ratio="0.5" textColor="#000000" verticalTextPosition="bottom" visible="true" width="93.390625" x="4.131930056233841" xml:space="preserve" y="3.137114820230863">SubComponents<y:LabelModel><y:SmartEdgeLabelModel autoRotationEnabled="false" defaultAngle="0.0" defaultDistance="10.0"/></y:LabelModel><y:ModelParameter><y:SmartEdgeLabelModelParameter angle="6.283185307179586" distance="32.411269642825744" distanceToCenter="false" position="left" ratio="-20.21303304511612" segment="-1"/></y:ModelParameter><y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" frozen="true" placement="anywhere" side="anywhere" sideReference="relative_to_edge_flow"/></y:EdgeLabel>
+          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="18.701171875" horizontalTextPosition="center" iconTextGap="4" modelName="custom" preferredPlacement="anywhere" ratio="0.5" textColor="#000000" verticalTextPosition="bottom" visible="true" width="93.390625" x="4.477322454750947" xml:space="preserve" y="2.0532923122915463">SubComponents<y:LabelModel><y:SmartEdgeLabelModel autoRotationEnabled="false" defaultAngle="0.0" defaultDistance="10.0"/></y:LabelModel><y:ModelParameter><y:SmartEdgeLabelModelParameter angle="6.283185307179586" distance="32.411269642825744" distanceToCenter="false" position="left" ratio="-20.21303304511612" segment="-1"/></y:ModelParameter><y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" frozen="true" placement="anywhere" side="anywhere" sideReference="relative_to_edge_flow"/></y:EdgeLabel>
           <y:BendStyle smoothed="false"/>
         </y:PolyLineEdge>
       </data>

--- a/assets/ERM/ERM_EntitiesWithAttributes_EN.svg
+++ b/assets/ERM/ERM_EntitiesWithAttributes_EN.svg
@@ -233,22 +233,22 @@
         <path d="M125 -464 L125 1711.8135 L1520 1711.8135 L1520 -464 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath52">
-        <path d="M-111.0016 -824.4 L1283.9984 -824.4 L1283.9984 2037.6 L-111.0016 2037.6 L-111.0016 -824.4 Z"/>
+        <path d="M-111.0016 -858.516 L1283.9984 -858.516 L1283.9984 2003.484 L-111.0016 2003.484 L-111.0016 -858.516 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath53">
-        <path d="M125 395.1011 L125 2398 L1520 2398 L1520 395.1011 Z"/>
+        <path d="M125 429.2172 L125 2398 L1520 2398 L1520 429.2172 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath54">
-        <path d="M125 -464 L125 395.1011 L1520 395.1011 L1520 -464 Z"/>
+        <path d="M125 -464 L125 429.2172 L1520 429.2172 L1520 -464 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath55">
-        <path d="M-57.4643 -381.8922 L1048.1704 -381.8922 L1048.1704 1886.4421 L-57.4643 1886.4421 L-57.4643 -381.8922 Z"/>
+        <path d="M-57.4643 -378.8341 L1048.1704 -378.8341 L1048.1704 1889.5002 L-57.4643 1889.5002 L-57.4643 -378.8341 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath56">
-        <path d="M125 55.1589 L125 2398 L1520 2398 L1520 55.1589 Z"/>
+        <path d="M125 51.3004 L125 2398 L1520 2398 L1520 51.3004 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath57">
-        <path d="M125 -464 L125 55.1589 L1520 55.1589 L1520 -464 Z"/>
+        <path d="M125 -464 L125 51.3004 L1520 51.3004 L1520 -464 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath58">
         <path d="M-111.3304 -2234.0564 L1099.2458 -2234.0564 L1099.2458 249.5774 L-111.3304 249.5774 L-111.3304 -2234.0564 Z"/>
@@ -374,36 +374,42 @@
         <path d="M131.0209 -195.02 L131.0209 1199.98 L-2730.979 1199.98 L-2730.979 -195.02 L131.0209 -195.02 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath99">
-        <path d="M405.6578 665.139 L-989.3422 665.139 L-989.3422 -2196.8611 L405.6578 -2196.8611 L405.6578 665.139 Z"/>
+        <path d="M304.1516 758.0715 L-1077.5774 566.1084 L-683.7433 -2268.6648 L697.9857 -2076.7017 L304.1516 758.0715 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath100">
-        <path d="M0 10 L0 -10 L-12 -10 L-12 10 Z"/>
+        <path d="M-12 10 L-0 10 L0 -10 L-12 -10 L-12 10 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath101">
-        <path d="M-832.4125 244.3961 L-832.4125 -1150.6039 L2029.5875 -1150.6039 L2029.5875 244.3961 L-832.4125 244.3961 Z"/>
+        <path d="M405.6499 557.4282 L-989.3501 557.4282 L-989.3501 -2304.5718 L405.6499 -2304.5718 L405.6499 557.4282 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath102">
-        <path d="M-2583.9185 285.0784 L-2583.9185 -1109.9216 L278.0815 -1109.9216 L278.0815 285.0784 L-2583.9185 285.0784 Z"/>
+        <path d="M0 10 L0 -10 L-12 -10 L-12 10 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath103">
-        <path d="M-438.8335 -2517.3586 L956.1665 -2517.3586 L956.1665 344.6414 L-438.8335 344.6414 L-438.8335 -2517.3586 Z"/>
+        <path d="M-866.5147 244.3961 L-866.5147 -1150.6039 L1995.4852 -1150.6039 L1995.4854 244.3961 L-866.5147 244.3961 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath104">
-        <path d="M-2583.9446 817.5325 L-2583.9446 -577.4675 L278.0554 -577.4675 L278.0554 817.5325 L-2583.9446 817.5325 Z"/>
+        <path d="M-2583.9185 285.0784 L-2583.9185 -1109.9216 L278.0815 -1109.9216 L278.0815 285.0784 L-2583.9185 285.0784 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath105">
-        <path d="M-993.8999 -2517.3586 L401.1001 -2517.3586 L401.1001 344.6414 L-993.8999 344.6414 L-993.8999 -2517.3586 Z"/>
+        <path d="M-438.8335 -2517.3586 L956.1665 -2517.3586 L956.1665 344.6414 L-438.8335 344.6414 L-438.8335 -2517.3586 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath106">
-        <path d="M-1016.3073 -1259.6045 L378.6927 -1259.6045 L378.6927 1602.3955 L-1016.3073 1602.3955 L-1016.3073 -1259.6045 Z"/>
+        <path d="M-2583.9446 817.5325 L-2583.9446 -577.4675 L278.0554 -577.4675 L278.0554 817.5325 L-2583.9446 817.5325 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath107">
-        <path d="M-970.003 1118.1021 L-970.003 -276.8979 L1891.9971 -276.8979 L1891.9971 1118.1021 L-970.003 1118.1021 Z"/>
+        <path d="M-993.8999 -2517.3586 L401.1001 -2517.3586 L401.1001 344.6414 L-993.8999 344.6414 L-993.8999 -2517.3586 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath108">
-        <path d="M756.639 -1118.1021 L756.639 276.8979 L-2105.3608 276.8979 L-2105.3608 -1118.1021 L756.639 -1118.1021 Z"/>
+        <path d="M-1016.3073 -1259.6045 L378.6927 -1259.6045 L378.6927 1602.3954 L-1016.3073 1602.3955 L-1016.3073 -1259.6045 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath109">
+        <path d="M-970.003 1118.1021 L-970.003 -276.8979 L1891.9969 -276.8979 L1891.9971 1118.1021 L-970.003 1118.1021 Z"/>
+      </clipPath>
+      <clipPath clipPathUnits="userSpaceOnUse" id="clipPath110">
+        <path d="M756.639 -1118.1021 L756.639 276.8979 L-2105.3608 276.8979 L-2105.3608 -1118.1021 L756.639 -1118.1021 Z"/>
+      </clipPath>
+      <clipPath clipPathUnits="userSpaceOnUse" id="clipPath111">
         <path d="M-2312.2915 521.6946 L-2312.2915 -873.3054 L549.7085 -873.3054 L549.7085 521.6946 L-2312.2915 521.6946 Z"/>
       </clipPath>
     </defs>
@@ -927,55 +933,56 @@
       <text x="346.053" xml:space="preserve" y="1891.5909" clip-path="url(#clipPath2)" stroke="none">Fax</text>
       <text x="346.053" xml:space="preserve" y="1906.2921" clip-path="url(#clipPath2)" stroke="none">Phone*</text>
     </g>
-    <g text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,111.0016,824.4)" image-rendering="optimizeQuality">
+    <g text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,111.0016,858.516)" image-rendering="optimizeQuality">
       <image x="0" y="0" clip-path="url(#clipPath52)" width="271" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQ8AAADuCAYAAAAnQIKtAAAFr0lEQVR4Xu3cV49d&#13;&#10;VRaF0e0Gkww2ORmaQuSMyElCxG7g//8f1tTuqy4ZRJhVRjrWWNJ49Dl+2Z/WPtfy&#13;&#10;WsYYY4wxxhhjjDHGGGOMMeafnSvjX+fcBRzS+XOccx23ZfLgvPDucXXcM+4d9wGH&#13;&#10;lPMbOcs50znbp5Bcypw2jTw4L3pgPDRujIfHI8Ah5fzG9fHguH/tkGRJuJSAJByp&#13;&#10;Uh6clzw2nh43x/Pj38Bh5Qw/O54cj64dkSwJFw5I/nA2joQjhUo0zsar483xzngX&#13;&#10;OKSc37fHG+PltUPyxNo3i2wgWRzqyR9Oha6vHY6X1n7hR+Oz8SVwaF+MT8cHay8E&#13;&#10;Z+PxcW3txaHaPk5bR75x5KpytnY4Eo2vx3fj+/EDcEg5v/HN+GrtpSBbyM21v2lm&#13;&#10;cai2j8Tj6tp3oGwduark4QnHj+On8TNwaDnH/1l7Gcgm8v54ce2FIZ8r8u3jb0+K&#13;&#10;k3tPriwp0Vtrbx15SV74C3BHSESyEGQxyILwytofUK+tC8Qja0s+lOZDSq4suR9l&#13;&#10;3cnLbv0LAMeU85ztI9eXT8Zr46m1bx35dPG353w88pNOvs5mrREPuLPcGo/X1/5U&#13;&#10;IR7AHxIPoCIeQEU8gIp4ABXxACriAVTEA6iIB1ARD6AiHkBFPICKeAAV8QAq4gFU&#13;&#10;xAOonI9H/jPkxOOZJR7AnxAPoCIeQEU8gIp4ABXxACriAVTEA6iIB1D5vXj4F6bA&#13;&#10;nzofD/88HfjLxAOoiAdQEQ+gIh5ARTyAingAFfEAKuIBVMQDqIgHUBEPoCIeQEU8&#13;&#10;gIp4ABXxACriAVTEA6iIB1ARD6AiHkBFPICKeAAV8QAq4gFUxAOoiAdQEQ+gIh5A&#13;&#10;RTyAingAFfEAKuIBVMQDqIgHUBEPoCIeQEU8gIp4ABXxACriAVTEA6iIB1ARD6Ai&#13;&#10;HkBFPICKeAAV8QAq4gFUxAOoiAdQEQ+gIh5ARTyAingAFfEAKuIBVMQDqIgHUBEP&#13;&#10;oCIeQEU8gIp4ABXxACriAVTEA6iIB1ARD6AiHkBFPICKeAAV8QAq4gFUxAOoiAdQ&#13;&#10;EQ+gIh5ARTyAingAFfEAKuIBVMQDqIgHUBEPoCIeQEU8gIp4ABXxACriAVTEA6iI&#13;&#10;B1ARD6AiHkBFPICKeAAV8QAq4gFUxAOoiAdQEQ+gIh5ARTyAingAFfEAKuIBVMQD&#13;&#10;qIgHUBEPoCIeQEU8gIp4ABXxACriAVTEA6iIB1ARD6AiHkBFPICKeAAV8QAq4gFU&#13;&#10;xAOoiAdQEQ+gIh5ARTyAingAFfEAKuIBVMQDqIgHUBEPoCIeQEU8gIp4ABXxACri&#13;&#10;AVTEA6iIB1ARD6AiHkBFPICKeAAV8QAq4gFUxAOoiAdQEQ+gIh5ARTyAingAFfEA&#13;&#10;KuIBVMQDqIgHUBEPoCIeQEU8gIp4ABXxACriAVTEA6iIB1ARD6AiHkBFPICKeAAV&#13;&#10;8QAq4gFUxAOoiAdQEQ+gIh5ARTyAingAFfEAKuIBVMQDqIgHULmt8Xh+vDO+GN8v&#13;&#10;8YA7yfl4fDxeG0+tC8bjnnF93Bxvjs/Gd+On9du/AHBMOc8/jq/Hh+OV8eS4Nu5a&#13;&#10;xVwZV9euT1aYV8dHa78gV5f/rv1S4LhyjrN1fLv2Z4n3xovjsXH/ukA8srI8sPaD&#13;&#10;zta+umT7SECygeQKAxxXznGuK1+tvRy8MZ4bN9b+bJEbSDWn7x65umT7eHntD6e5&#13;&#10;F32+dqnyUuCYcoazEHww3lp7SXhi7StLbh5ZIqo5bR9ZX/Lh9Jm1V5p8jX177ZBk&#13;&#10;zQGOKbeJfM/Md478qppvHQ+tC24dp8kDUqAEJBvI42tH5Lnxwv+cAYdyOrsJRn4Q&#13;&#10;ya8rj67/hyPfOq6sS5gEJBtIHppvIHnBjfEIcGi5UeQs54eRLAj5hfXSwnGaPOwU&#13;&#10;kWwieUliAhxbznLOdKKRM36p4bh18vBTTIDjOp3l2xoMY4wxxhhjjDHGGGOMMcYY&#13;&#10;c+v8Co270N/tA60ZAAAAAElFTkSuQmCC" height="238" preserveAspectRatio="none"/>
-      <rect x="244.0016" y="368.4" transform="matrix(1,0,0,1,-236.0016,-360.4)" clip-path="url(#clipPath53)" fill="white" width="250.7891" image-rendering="auto" rx="4" ry="4" height="217.1621" stroke="none"/>
-      <rect x="244.0016" y="368.4" transform="matrix(1,0,0,1,-236.0016,-360.4)" clip-path="url(#clipPath54)" fill="rgb(237,237,237)" width="250.7891" image-rendering="auto" rx="4" ry="4" height="217.1621" stroke="none"/>
-      <rect stroke-linecap="butt" x="244.0016" y="368.4" transform="matrix(1,0,0,1,-236.0016,-360.4)" clip-path="url(#clipPath2)" fill="none" width="250.7891" image-rendering="auto" rx="4" ry="4" height="217.1621" stroke-miterlimit="1.45"/>
-      <line stroke-linecap="butt" transform="matrix(1,0,0,1,-236.0016,-360.4)" clip-path="url(#clipPath2)" fill="none" x1="244.0016" x2="494.7907" y1="395.1012" image-rendering="auto" y2="395.1012" stroke-miterlimit="1.45"/>
+      <rect x="244.0016" y="402.516" transform="matrix(1,0,0,1,-236.0016,-394.516)" clip-path="url(#clipPath53)" fill="white" width="250.7891" image-rendering="auto" rx="4" ry="4" height="217.1621" stroke="none"/>
+      <rect x="244.0016" y="402.516" transform="matrix(1,0,0,1,-236.0016,-394.516)" clip-path="url(#clipPath54)" fill="rgb(237,237,237)" width="250.7891" image-rendering="auto" rx="4" ry="4" height="217.1621" stroke="none"/>
+      <rect stroke-linecap="butt" x="244.0016" y="402.516" transform="matrix(1,0,0,1,-236.0016,-394.516)" clip-path="url(#clipPath2)" fill="none" width="250.7891" image-rendering="auto" rx="4" ry="4" height="217.1621" stroke-miterlimit="1.45"/>
+      <line stroke-linecap="butt" transform="matrix(1,0,0,1,-236.0016,-394.516)" clip-path="url(#clipPath2)" fill="none" x1="244.0016" x2="494.7907" y1="429.2172" image-rendering="auto" y2="429.2172" stroke-miterlimit="1.45"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" font-family="sans-serif" transform="matrix(1,0,0,1,-125,464)" stroke-linecap="butt">
-      <text x="315.6949" xml:space="preserve" y="386.4644" clip-path="url(#clipPath2)" stroke="none">ComponentInstance</text>
-      <text x="248.0016" xml:space="preserve" y="413.1656" clip-path="url(#clipPath2)" stroke="none">ID*</text>
-      <text x="248.0016" xml:space="preserve" y="427.8668" clip-path="url(#clipPath2)" stroke="none">ProductionSite [Location]</text>
-      <text x="248.0016" xml:space="preserve" y="442.568" clip-path="url(#clipPath2)" stroke="none">Machine</text>
-      <text x="248.0016" xml:space="preserve" y="457.2691" clip-path="url(#clipPath2)" stroke="none">Tool</text>
-      <text x="248.0016" xml:space="preserve" y="471.9703" clip-path="url(#clipPath2)" stroke="none">Cavity</text>
-      <text x="248.0016" xml:space="preserve" y="486.6715" clip-path="url(#clipPath2)" stroke="none">SerialNumber</text>
-      <text x="248.0016" xml:space="preserve" y="501.3727" clip-path="url(#clipPath2)" stroke="none">ProductionLotNumber</text>
-      <text x="248.0016" xml:space="preserve" y="516.0738" clip-path="url(#clipPath2)" stroke="none">ProductionDate [Date]</text>
-      <text x="248.0016" xml:space="preserve" y="530.775" clip-path="url(#clipPath2)" stroke="none">DateOfReceipt [Date]</text>
-      <text x="248.0016" xml:space="preserve" y="545.4761" clip-path="url(#clipPath2)" stroke="none">Attachment [Attachment]</text>
-      <text x="248.0016" xml:space="preserve" y="560.1773" clip-path="url(#clipPath2)" stroke="none">Comment</text>
-      <text x="248.0016" xml:space="preserve" y="574.8785" clip-path="url(#clipPath2)" stroke="none">BusinessKeys [BusinessKey]</text>
+      <text x="315.6949" xml:space="preserve" y="420.5804" clip-path="url(#clipPath2)" stroke="none">ComponentInstance</text>
+      <text x="248.0016" xml:space="preserve" y="447.2816" clip-path="url(#clipPath2)" stroke="none">ID*</text>
+      <text x="248.0016" xml:space="preserve" y="461.9828" clip-path="url(#clipPath2)" stroke="none">ProductionSite [Location]</text>
+      <text x="248.0016" xml:space="preserve" y="476.684" clip-path="url(#clipPath2)" stroke="none">Machine</text>
+      <text x="248.0016" xml:space="preserve" y="491.3851" clip-path="url(#clipPath2)" stroke="none">Tool</text>
+      <text x="248.0016" xml:space="preserve" y="506.0863" clip-path="url(#clipPath2)" stroke="none">Cavity</text>
+      <text x="248.0016" xml:space="preserve" y="520.7875" clip-path="url(#clipPath2)" stroke="none">SerialNumber</text>
+      <text x="248.0016" xml:space="preserve" y="535.4886" clip-path="url(#clipPath2)" stroke="none">ProductionLotNumber</text>
+      <text x="248.0016" xml:space="preserve" y="550.1898" clip-path="url(#clipPath2)" stroke="none">ProductionDate [Date]</text>
+      <text x="248.0016" xml:space="preserve" y="564.891" clip-path="url(#clipPath2)" stroke="none">DateOfReceipt [Date]</text>
+      <text x="248.0016" xml:space="preserve" y="579.5922" clip-path="url(#clipPath2)" stroke="none">Attachment [Attachment]</text>
+      <text x="248.0016" xml:space="preserve" y="594.2933" clip-path="url(#clipPath2)" stroke="none">Comment</text>
+      <text x="248.0016" xml:space="preserve" y="608.9945" clip-path="url(#clipPath2)" stroke="none">BusinessKeys [BusinessKey]</text>
     </g>
-    <g text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1.2617,0,0,1.2617,72.5038,481.8405)" image-rendering="optimizeQuality">
-      <image x="0" y="0" clip-path="url(#clipPath55)" width="276" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAARQAAAEFCAYAAAAi+hhHAAAFqklEQVR4Xu3c284U&#13;&#10;VRSF0a2IIigqKKAYRDwQxFMQgggqimff/31cM2UnBK/sf5qYyljJuKSKm/qy9m7C&#13;&#10;WsYYY4wxxhhjjDHGGGOMMWb/89zfngd27/C91+cQkVPjhXF6vDheAnYn33bkO8/3&#13;&#10;fohLZQ4xycPPjHPj1XF+vAbsUr7vV8bLa4tLwnLiqDwdk7Pj9fHmuDKujneB3cm3&#13;&#10;/c64PC6sbYHIMnHiqCQmeUhikgfnJTfGzfHJ+BTYndvj1vhoXBuX1rax5DiUJhw9&#13;&#10;uTPJQ7ICJSZ5wRfj3ngwvgF2J9/2/XFnbXG5Pt5a23XH0VtK/tBhO8kxJ5tJYpKX&#13;&#10;PR5Pxk/A7uTb/mE8GnfXtq3kGJTFIvcpRwcldyc5P+XOJMecbCaPxy/jd2C3fl1b&#13;&#10;WB6ubZG4vrZrj9ylHHXsSVBSo5ydUqesPtlO8pK88E9gt/5Y2+Lw3dqOPjmhXFzb&#13;&#10;rz4nCkrWnNz85rIm56usRIIC+3YIyvfjq/HB2q4+BAX41wQFqBEUoEZQgBpBAWoE&#13;&#10;BagRFKBGUIAaQQFqBAWoERSg5tmgfLgEBTjS00HJf2EgKMDRBAWoERSgRlCAGkEB&#13;&#10;agQFqBEUoEZQgBpBAWqe/Zey/uk9cDRBAWoEBagRFKBGUIAaQQFqBAWoERSgRlCA&#13;&#10;GkEBagQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFqBAWoERSgRlCAGkEBagQFqBEU&#13;&#10;oEZQgBpBAWoEBagRFKBGUIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQgBpBAWoE&#13;&#10;BagRFKBGUIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagRFKBGUIAa&#13;&#10;QQFqBAWoERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFqBAWoERSg&#13;&#10;RlCAGkEBagQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFqBAWoERSgRlCAGkEBagQF&#13;&#10;qBEUoEZQgBpBAWoEBagRFKBGUIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQgBpB&#13;&#10;AWoEBagRFKBGUIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagRFKBG&#13;&#10;UIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFqBAWo&#13;&#10;ERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFqBAWoERSgRlCAGkEB&#13;&#10;agQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQ&#13;&#10;gBpBAWoEBagRFKBGUIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagR&#13;&#10;FKBGUIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFq&#13;&#10;BAWoERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFqBAWoERSgRlCA&#13;&#10;GkEBagQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFq/rOgnB9Xxyfj6/Fk/Lb++RcA&#13;&#10;9iNB+Xl8N+6MG+PiOmFQTo9Xx5Vxc9xbW7FSrkQlmwqwP7+OH8fD8cW4Pi6MM+sE&#13;&#10;QXlhnB1vra1QeXCOPY/Xtqnk+APsT2Ly7dqWiFtru/bI9UdOLWnDUXNqbUV6fW3H&#13;&#10;no/Hl+P+2sLyCNidbCUPxt213Z2+Py6Nc2tbMo4OSlabHHuypWTdSVRyOZP7lM/W&#13;&#10;trEA+/L5uL22a47r4/LatpOX1rZkHD0pUaKSNSd1yqaSUiUs18Z7a3shsA/5pvNt&#13;&#10;vzveXtsvO/lhJieVE20nh8kDDptKHpqw5AWJyxvALmUjyQ8yOZ1kM6nE5OnJw7Lu&#13;&#10;5MHZWPISYJ/yjWeJyPeehaIak6cnDz7Ii4D9OXzjxhhjjDHGGGOMMcYYY/6v8xdf&#13;&#10;IfgRmH965gAAAABJRU5ErkJggg==" height="261" preserveAspectRatio="none"/>
-      <rect x="208.121" y="28.4577" transform="matrix(0.7926,0,0,0.7926,-156.5355,-14.1399)" clip-path="url(#clipPath56)" fill="white" width="322.5503" image-rendering="auto" rx="4" ry="4" height="304.3065" stroke="none"/>
-      <rect x="208.121" y="28.4577" transform="matrix(0.7926,0,0,0.7926,-156.5355,-14.1399)" clip-path="url(#clipPath57)" fill="rgb(237,237,237)" width="322.5503" image-rendering="auto" rx="4" ry="4" height="304.3065" stroke="none"/>
-      <rect stroke-linecap="butt" x="208.121" y="28.4577" transform="matrix(0.7926,0,0,0.7926,-156.5355,-14.1399)" clip-path="url(#clipPath2)" fill="none" width="322.5503" image-rendering="auto" rx="4" ry="4" height="304.3065" stroke-miterlimit="1.45"/>
-      <line stroke-linecap="butt" transform="matrix(0.7926,0,0,0.7926,-156.5355,-14.1399)" clip-path="url(#clipPath2)" fill="none" x1="208.121" x2="530.6713" y1="55.1589" image-rendering="auto" y2="55.1589" stroke-miterlimit="1.45"/>
+    <g text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1.2617,0,0,1.2617,72.5038,477.9821)" image-rendering="optimizeQuality">
+      <image x="0" y="0" clip-path="url(#clipPath55)" width="276" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAARQAAAENCAYAAADOqZoqAAAFxklEQVR4Xu3cWast&#13;&#10;1RmG0WkX++4Y+0S2JmKXYGLf54gdmv//fzI/ygUiBHTtx5tivDAurXVVD3PWPriW&#13;&#10;mZmZmZmZmZmZmZmZnX/3/Oxe4PQu73u+S0Tu2+7fHtj+tD0InM6822Pe83nfL3FJ&#13;&#10;donJPPyh7dHt8e2J7UnglOb9fmx7eB1xmbDcOiq/jMkj21Pbn7cXtpe3vwCnM+/2&#13;&#10;S9vz2511HCDmMHHrqExM5iETk3nw/Mhr2xvb29s/gNN5Z3tre317ZXtuHSeWuQ5N&#13;&#10;E67efDOZh8wRaGIyP/Du9uH26fYZcDrzbn+8vbeOuNxsz67jc8fVp5T5jy6nk7nm&#13;&#10;zMlkYjI/dnf7ZvsWOJ15t7/evtg+WMdpZa5Bc7CY7ylXB2W+ncz9ab6ZzDVnTiZ3&#13;&#10;t++3H4HT+mEdYfl8HQeJm3V89phvKVddeyYoU6O5O02d5ugzp5P5kfnB/wKn9dM6&#13;&#10;Dg5frePqMzeUZ9bxV59bBWWOOfPldz7WzP1qjkSCAud2Ccp/tve3v63j04egAL+b&#13;&#10;oAAZQQEyggJkBAXICAqQERQgIyhARlCAjKAAGUEBMr8Oyt+XoABX+mVQ5n9hICjA&#13;&#10;1QQFyAgKkBEUICMoQEZQgIygABlBATKCAmR+/S9l/dN74GqCAmQEBcgICpARFCAj&#13;&#10;KEBGUICMoAAZQQEyggJkBAXICAqQERQgIyhARlCAjKAAGUEBMoICZAQFyAgKkBEU&#13;&#10;ICMoQEZQgIygABlBATKCAmQEBcgICpARFCAjKEBGUICMoAAZQQEyggJkBAXICAqQ&#13;&#10;ERQgIyhARlCAjKAAGUEBMoICZAQFyAgKkBEUICMoQEZQgIygABlBATKCAmQEBcgI&#13;&#10;CpARFCAjKEBGUICMoAAZQQEyggJkBAXICAqQERQgIyhARlCAjKAAGUEBMoICZAQF&#13;&#10;yAgKkBEUICMoQEZQgIygABlBATKCAmQEBcgICpARFCAjKEBGUICMoAAZQQEyggJk&#13;&#10;BAXICAqQERQgIyhARlCAjKAAGUEBMoICZAQFyAgKkBEUICMoQEZQgIygABlBATKC&#13;&#10;AmQEBcgICpARFCAjKEBGUICMoAAZQQEyggJkBAXICAqQERQgIyhARlCAjKAAGUEB&#13;&#10;MoICZAQFyAgKkBEUICMoQEZQgIygABlBATKCAmQEBcgICpARFCAjKEBGUICMoAAZ&#13;&#10;QQEyggJkBAXICAqQERQgIyhARlCAjKAAGUEBMoICZAQFyAgKkBEUICMoQEZQgIyg&#13;&#10;ABlBATKCAmQEBcgICpARFCAjKEBGUICMoAAZQQEyggJkBAXICAqQERQgIyhARlCA&#13;&#10;jKAAGUEBMoICZAQFyAgKkBEUICMoQEZQgIygABlBATKCAmQEBcgICpARFCAjKEBG&#13;&#10;UICMoAAZQQEyggJkBAXICAqQERQgIyhARlCAjKAAGUEBMoICZAQFyAgKkBEUICMo&#13;&#10;QEZQgIygABlBATKCAmQEBcgICpARFCAjKEBGUICMoAAZQQEyggJkBAXICAqQERQg&#13;&#10;IyhARlCAjKAAGUEBMoICZAQFyAgKkBEUICMoQEZQgIygAJk/LChPbC9vb2+fbt8s&#13;&#10;QYGzm6B8t321vbe9toKgPLA9vr2wvbF9uN1dR7kmKsA5/bCOw8Pn27vbzXZne2jd&#13;&#10;Iij3b49uz66jUP9ax7Xn63VcfaZgwPlMTOZ08tE6bifz2eOpddxapg1X7b51FGke&#13;&#10;NNeeN7d/b59sX2xfruNHgXOYd3rMwWFuJP9cx/eT57bH1nFruTooc7SZB8wp5Znt&#13;&#10;r9vr2zvrOAZNXOZ+BZzDvNNzE5mQvLWOm8mL6/jjzBwu5pBx9aZE84A55kxU7qzj&#13;&#10;e8qE5WZ7dR0/CJzDvNM32yvruJXM546JycPr+ARy9enksktU5qQyD52PtPMDT6/j&#13;&#10;1AKcyxwc5v2ev/DOQeLBdcTk3hVtojIPu4RlfmCOP8A5zTs+N5MJybz3tz6Z/L/N&#13;&#10;gy+BAc7r8q6bmZmZmZmZmZmZmZmZmZn9lv0PAw7FgKpKIcAAAAAASUVORK5CYII=" height="269" preserveAspectRatio="none"/>
+      <rect x="208.121" y="24.5992" transform="matrix(0.7926,0,0,0.7926,-156.5355,-11.0818)" clip-path="url(#clipPath56)" fill="white" width="322.5503" image-rendering="auto" rx="4" ry="4" height="312.0234" stroke="none"/>
+      <rect x="208.121" y="24.5992" transform="matrix(0.7926,0,0,0.7926,-156.5355,-11.0818)" clip-path="url(#clipPath57)" fill="rgb(237,237,237)" width="322.5503" image-rendering="auto" rx="4" ry="4" height="312.0234" stroke="none"/>
+      <rect stroke-linecap="butt" x="208.121" y="24.5992" transform="matrix(0.7926,0,0,0.7926,-156.5355,-11.0818)" clip-path="url(#clipPath2)" fill="none" width="322.5503" image-rendering="auto" rx="4" ry="4" height="312.0234" stroke-miterlimit="1.45"/>
+      <line stroke-linecap="butt" transform="matrix(0.7926,0,0,0.7926,-156.5355,-11.0818)" clip-path="url(#clipPath2)" fill="none" x1="208.121" x2="530.6713" y1="51.3004" image-rendering="auto" y2="51.3004" stroke-miterlimit="1.45"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" font-family="sans-serif" transform="matrix(1,0,0,1,-125,464)" stroke-linecap="butt">
-      <text x="320.0397" xml:space="preserve" y="46.5222" clip-path="url(#clipPath2)" stroke="none">ComponentMaster</text>
-      <text x="212.121" xml:space="preserve" y="73.2234" clip-path="url(#clipPath2)" stroke="none">ID*</text>
-      <text x="212.121" xml:space="preserve" y="87.9245" clip-path="url(#clipPath2)" stroke="none">CustomerPartNumber</text>
-      <text x="212.121" xml:space="preserve" y="102.6257" clip-path="url(#clipPath2)" stroke="none">SupplierPartNumber</text>
-      <text x="212.121" xml:space="preserve" y="117.3269" clip-path="url(#clipPath2)" stroke="none">Color</text>
-      <text x="212.121" xml:space="preserve" y="132.028" clip-path="url(#clipPath2)" stroke="none">MaterialGroup (VDA 231-106)</text>
-      <text x="212.121" xml:space="preserve" y="146.7292" clip-path="url(#clipPath2)" stroke="none">MaterialClass (VDA 231-200)</text>
-      <text x="212.121" xml:space="preserve" y="161.4304" clip-path="url(#clipPath2)" stroke="none">MaterialName</text>
-      <text x="212.121" xml:space="preserve" y="176.1316" clip-path="url(#clipPath2)" stroke="none">OemIdentifier</text>
-      <text x="212.121" xml:space="preserve" y="190.8327" clip-path="url(#clipPath2)" stroke="none">MaterialIdentifiers (VDA 231-300)</text>
-      <text x="212.121" xml:space="preserve" y="205.5339" clip-path="url(#clipPath2)" stroke="none">SurfaceIdentifiers (VDA 231-300)</text>
-      <text x="212.121" xml:space="preserve" y="220.2351" clip-path="url(#clipPath2)" stroke="none">Specifications (List of [Specification])</text>
-      <text x="212.121" xml:space="preserve" y="234.9362" clip-path="url(#clipPath2)" stroke="none">Stack [Stack]</text>
-      <text x="212.121" xml:space="preserve" y="249.6374" clip-path="url(#clipPath2)" stroke="none">SpecificationCustomizations [SpecificationCustomizations]</text>
-      <text x="212.121" xml:space="preserve" y="264.3386" clip-path="url(#clipPath2)" stroke="none">Attachment [Attachment]</text>
-      <text x="212.121" xml:space="preserve" y="279.0398" clip-path="url(#clipPath2)" stroke="none">Comment</text>
-      <text x="212.121" xml:space="preserve" y="293.7409" clip-path="url(#clipPath2)" stroke="none">BusinessKeys [BusinessKey]</text>
-      <text x="212.121" xml:space="preserve" y="308.4421" clip-path="url(#clipPath2)" stroke="none">Mass [Mass]</text>
-      <text x="212.121" xml:space="preserve" y="323.1433" clip-path="url(#clipPath2)" stroke="none">NumberOfParts</text>
+      <text x="320.0397" xml:space="preserve" y="42.6637" clip-path="url(#clipPath2)" stroke="none">ComponentMaster</text>
+      <text x="212.121" xml:space="preserve" y="69.3649" clip-path="url(#clipPath2)" stroke="none">ID*</text>
+      <text x="212.121" xml:space="preserve" y="84.066" clip-path="url(#clipPath2)" stroke="none">Designation</text>
+      <text x="212.121" xml:space="preserve" y="98.7672" clip-path="url(#clipPath2)" stroke="none">CustomerPartNumber</text>
+      <text x="212.121" xml:space="preserve" y="113.4684" clip-path="url(#clipPath2)" stroke="none">SupplierPartNumber</text>
+      <text x="212.121" xml:space="preserve" y="128.1696" clip-path="url(#clipPath2)" stroke="none">Color</text>
+      <text x="212.121" xml:space="preserve" y="142.8707" clip-path="url(#clipPath2)" stroke="none">MaterialGroup (VDA 231-106)</text>
+      <text x="212.121" xml:space="preserve" y="157.5719" clip-path="url(#clipPath2)" stroke="none">MaterialClass (VDA 231-200)</text>
+      <text x="212.121" xml:space="preserve" y="172.2731" clip-path="url(#clipPath2)" stroke="none">MaterialName</text>
+      <text x="212.121" xml:space="preserve" y="186.9742" clip-path="url(#clipPath2)" stroke="none">OemIdentifier</text>
+      <text x="212.121" xml:space="preserve" y="201.6754" clip-path="url(#clipPath2)" stroke="none">MaterialIdentifiers (VDA 231-300)</text>
+      <text x="212.121" xml:space="preserve" y="216.3766" clip-path="url(#clipPath2)" stroke="none">SurfaceIdentifiers (VDA 231-300)</text>
+      <text x="212.121" xml:space="preserve" y="231.0778" clip-path="url(#clipPath2)" stroke="none">Specifications (List of [Specification])</text>
+      <text x="212.121" xml:space="preserve" y="245.7789" clip-path="url(#clipPath2)" stroke="none">Stack [Stack]</text>
+      <text x="212.121" xml:space="preserve" y="260.4801" clip-path="url(#clipPath2)" stroke="none">SpecificationCustomizations [SpecificationCustomizations]</text>
+      <text x="212.121" xml:space="preserve" y="275.1813" clip-path="url(#clipPath2)" stroke="none">Attachment [Attachment]</text>
+      <text x="212.121" xml:space="preserve" y="289.8824" clip-path="url(#clipPath2)" stroke="none">Comment</text>
+      <text x="212.121" xml:space="preserve" y="304.5836" clip-path="url(#clipPath2)" stroke="none">BusinessKeys [BusinessKey]</text>
+      <text x="212.121" xml:space="preserve" y="319.2848" clip-path="url(#clipPath2)" stroke="none">Mass [Mass]</text>
+      <text x="212.121" xml:space="preserve" y="333.986" clip-path="url(#clipPath2)" stroke="none">NumberOfParts</text>
     </g>
     <g text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1.1523,0,0,1.1523,128.2909,2574.401)" image-rendering="optimizeQuality">
       <image x="0" y="0" clip-path="url(#clipPath58)" width="276" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAARQAAACbCAYAAACj4WTAAAAEaElEQVR4Xu3a7bNW&#13;&#10;YxjG4TskRCSFRDKRXuSdiZBC4v//f1znLM/MHr7tfZoxq+OaOT621v5y/+Za99Na&#13;&#10;xhhjjDHGGGOMMcYYY4wxZv9z6m/PALt3OO/1OTz42fHcOD2eH2eA3cnZjpzznPlD&#13;&#10;XCpz2EgSkrzspfHKODdeBXYnZztn/Ox4cW1xSVgqUUlMUqqEJC97Y7w13hlXgN3J&#13;&#10;2X57XBrnx8trWyZOHJX842wmiUkefHlcGzfGrXF73AF2JWf743F9vDsurm1jyaaS&#13;&#10;BePYkyKlTNlMUqwPx93x9bg3vgN2J2f7m/H5uDmuru3LJItFFoxjbSlHt5M8LJtJ&#13;&#10;YpKX/TQe/e0XYFdyrn8e98eXa9tWLq/tbiVbyrGDkruTrDq5M8lnTjaTB+O38QTY&#13;&#10;rcfj4do2liwS2VJy7ZEvlmN99iQoqVGqlEua3JdkO0m98sI/gd36Y22Lw4/ji/HB&#13;&#10;uLC2X31OFJTcn+RiJpc1369tJcrL/vkHAPtxCEquN/LZc31tVx+1oHyyBAWeFoIC&#13;&#10;1AgKUCMoQI2gADWCAtQIClAjKECNoAA1ggLUCApQIyhAjaAANUeD8tUSFOAEBAWo&#13;&#10;ERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBag5GhT/9R44EUEBagQFqBEUoEZQgBpB&#13;&#10;AWoEBagRFKBGUIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagRFKBG&#13;&#10;UIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFqBAWo&#13;&#10;ERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFqBAWoERSgRlCAGkEB&#13;&#10;agQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQ&#13;&#10;gBpBAWoEBagRFKBGUIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagR&#13;&#10;FKBGUIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFq&#13;&#10;BAWoERSgRlCAGkEBagQFqBEUoEZQgJr/PCh3lqDA0+I/C8q58c64Pe6NR+PJ+vcf&#13;&#10;AOxHgvLr+HF8Pj4YF9YJg3J6vDzeHjfG12srVsr1+9rCAuzP4/FwfDfujvfH+fHC&#13;&#10;OkFQnhsvjYtrK9Sna9tSHqxtU8nnTyoG7EfOdWLyw9qWiJtr+0rJ9Ue+WtKGY82z&#13;&#10;48x4bVweH43Pxrdru0+5D+xOznYWh9yd3B7X1rZUnF3bknHsoBw+e7KlvL62SuVy&#13;&#10;5tbafvXJxpLAAPuQM51PnPwIk2uOq+PNtd2lZrk41ufO0ckDDlF5bVxaW1jeW9t3&#13;&#10;FbAviciV8dbaLmJfWdvdSb5YTq0TTh5wiEoemrUntUpcckmTzQXYj5zr3JckJFkk&#13;&#10;cm9SicnRycPy0HxD5QVZfyKRAfYj5zpnPEtEznsWimpMjk4efJAXAftzOOPGGGOM&#13;&#10;McYYY4wxxhhj/q/zF5L55zK+XdpCAAAAAElFTkSuQmCC" height="155" preserveAspectRatio="none"/>
@@ -1307,80 +1314,89 @@
       <line transform="matrix(0,-1,1,0,320.02,-332.9791)" clip-path="url(#clipPath89)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>
     </g>
     <g stroke-linecap="butt" transform="matrix(1,0,0,1,-125,464)" fill="rgb(153,153,153)" text-rendering="geometricPrecision" shape-rendering="geometricPrecision" stroke-dasharray="6,2" stroke="rgb(153,153,153)" stroke-miterlimit="1.45">
-      <path fill="none" d="M436.6807 918.4282 L369.3961 918.4282 L369.3961 593.5376" clip-path="url(#clipPath2)"/>
-      <path d="M369.3961 585.5376 L364.3961 597.5376 L369.3961 594.5376 L374.3961 597.5376 Z" clip-path="url(#clipPath2)" stroke="none"/>
+      <path fill="none" d="M436.6807 918.4282 L369.3961 918.4282 L369.3961 627.6425" clip-path="url(#clipPath2)"/>
+      <path d="M369.3961 619.6425 L364.3961 631.6425 L369.3961 628.6425 L374.3961 631.6425 Z" clip-path="url(#clipPath2)" stroke="none"/>
     </g>
     <g stroke-linecap="butt" transform="matrix(1,0,0,1,-125,464)" fill="gray" text-rendering="geometricPrecision" font-family="sans-serif" shape-rendering="geometricPrecision" stroke="gray" stroke-miterlimit="1.45">
-      <text x="372.6655" xml:space="preserve" y="774.3174" clip-path="url(#clipPath2)" stroke="none">via ID</text>
+      <text x="372.6655" xml:space="preserve" y="790.2579" clip-path="url(#clipPath2)" stroke="none">via ID</text>
     </g>
     <g stroke-linecap="butt" transform="matrix(1,0,0,1,-125,464)" fill="rgb(153,153,153)" text-rendering="geometricPrecision" shape-rendering="geometricPrecision" stroke-dasharray="6,2" stroke="rgb(153,153,153)" stroke-miterlimit="1.45">
-      <path fill="none" d="M658.2 410.5702 L588.7217 410.5702 L588.7217 275.1156 L538.6624 275.1156" clip-path="url(#clipPath2)"/>
-      <path d="M530.6624 275.1156 L542.6624 280.1156 L539.6624 275.1156 L542.6624 270.1156 Z" clip-path="url(#clipPath2)" stroke="none"/>
+      <path fill="none" d="M658.2 410.5702 L588.7217 410.5702 L588.7217 316.8248 L538.6522 316.8248" clip-path="url(#clipPath2)"/>
+      <path d="M530.6522 316.8248 L542.6522 321.8248 L539.6522 316.8248 L542.6522 311.8248 Z" clip-path="url(#clipPath2)" stroke="none"/>
       <text x="619.257" y="405.0965" clip-path="url(#clipPath2)" font-family="sans-serif" stroke-dasharray="none" stroke="none" xml:space="preserve">via ID</text>
-      <path fill="none" stroke-dasharray="none" d="M539.6578 201.139 L662.8019 201.139" clip-path="url(#clipPath2)" stroke="black"/>
-      <line transform="matrix(-1,0,0,-1,530.6578,201.139)" clip-path="url(#clipPath99)" fill="none" x1="-15" x2="-15" y1="-8" y2="8" stroke-dasharray="none" stroke="black"/>
-      <line transform="matrix(-1,0,0,-1,530.6578,201.139)" clip-path="url(#clipPath100)" fill="none" x1="-10" x2="2" y1="0" y2="8" stroke-dasharray="none" stroke="black"/>
-      <line transform="matrix(-1,0,0,-1,530.6578,201.139)" clip-path="url(#clipPath100)" fill="none" x1="-10" x2="2" y1="0" y2="0" stroke-dasharray="none" stroke="black"/>
-      <line transform="matrix(-1,0,0,-1,530.6578,201.139)" clip-path="url(#clipPath100)" fill="none" x1="-10" x2="2" y1="0" y2="-8" stroke-dasharray="none" stroke="black"/>
+      <path fill="none" stroke-dasharray="none" d="M539.4892 243.7677 L539.5887 243.7573 L541.0676 243.377 L544.4137 242.1524 L547.5973 240.6187 L550.6001 238.7945 L553.4038 236.6979 L555.9901 234.3473 L558.3408 231.761 L560.4373 228.9573 L562.2615 225.9545 L563.7952 222.7709 L565.0199 219.4248 L565.9173 215.9345 L566.4692 212.3183 L566.6572 208.5946 L566.4692 204.8709 L565.9173 201.2548 L565.0198 197.7645 L563.7952 194.4184 L562.2615 191.2348 L560.4373 188.232 L558.3407 185.4283 L555.9901 182.842 L553.4038 180.4914 L550.6001 178.3948 L547.5973 176.5706 L544.4137 175.0369 L541.0676 173.8123 L537.5773 172.9148 L533.9612 172.3629 L530.6738 172.1969" clip-path="url(#clipPath2)" stroke="black"/>
+      <circle transform="matrix(-0.9905,0.1376,-0.1376,-0.9905,530.5748,245.0061)" clip-path="url(#clipPath99)" fill="white" r="5" stroke-dasharray="none" cx="-15" cy="0" stroke="none"/>
+      <circle transform="matrix(-0.9905,0.1376,-0.1376,-0.9905,530.5748,245.0061)" clip-path="url(#clipPath99)" fill="none" r="5" stroke-dasharray="none" cx="-15" cy="0" stroke="black"/>
+      <line transform="matrix(-0.9905,0.1376,-0.1376,-0.9905,530.5748,245.0061)" clip-path="url(#clipPath100)" fill="none" x1="-10" x2="2" y1="0" y2="8" stroke-dasharray="none" stroke="black"/>
+      <line transform="matrix(-0.9905,0.1376,-0.1376,-0.9905,530.5748,245.0061)" clip-path="url(#clipPath100)" fill="none" x1="-10" x2="2" y1="0" y2="0" stroke-dasharray="none" stroke="black"/>
+      <line transform="matrix(-0.9905,0.1376,-0.1376,-0.9905,530.5748,245.0061)" clip-path="url(#clipPath100)" fill="none" x1="-10" x2="2" y1="0" y2="-8" stroke-dasharray="none" stroke="black"/>
+    </g>
+    <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" font-family="sans-serif" transform="matrix(1,0,0,1,-125,464)" stroke-linecap="butt">
+      <text x="536.8058" xml:space="preserve" y="262.1939" clip-path="url(#clipPath2)" stroke="none">SubComponents</text>
+      <path fill="none" d="M539.6499 93.4282 L662.8221 93.4282" clip-path="url(#clipPath2)"/>
+      <line transform="matrix(-1,0,0,-1,530.6499,93.4282)" clip-path="url(#clipPath101)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
+      <line transform="matrix(-1,0,0,-1,530.6499,93.4282)" clip-path="url(#clipPath102)" fill="none" x1="-10" x2="2" y1="0" y2="8"/>
+      <line transform="matrix(-1,0,0,-1,530.6499,93.4282)" clip-path="url(#clipPath102)" fill="none" x1="-10" x2="2" y1="0" y2="0"/>
+      <line transform="matrix(-1,0,0,-1,530.6499,93.4282)" clip-path="url(#clipPath102)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-125,464)" stroke-linecap="butt">
-      <path fill="none" d="M369.3961 332.7394 L369.3961 359.4124" clip-path="url(#clipPath2)"/>
-      <line transform="matrix(0,1,-1,0,369.3961,368.4124)" clip-path="url(#clipPath101)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
-      <line transform="matrix(0,1,-1,0,369.3961,368.4124)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="8"/>
-      <line transform="matrix(0,1,-1,0,369.3961,368.4124)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="0"/>
-      <line transform="matrix(0,1,-1,0,369.3961,368.4124)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>
+      <path fill="none" d="M369.3961 336.6156 L369.3961 393.5147" clip-path="url(#clipPath2)"/>
+      <line transform="matrix(0,1,-1,0,369.3961,402.5147)" clip-path="url(#clipPath103)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
+      <line transform="matrix(0,1,-1,0,369.3961,402.5147)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="8"/>
+      <line transform="matrix(0,1,-1,0,369.3961,402.5147)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="0"/>
+      <line transform="matrix(0,1,-1,0,369.3961,402.5147)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-125,464)" stroke-linecap="butt">
       <path fill="none" d="M410.0784 2072.7241 L410.0784 2110.9185" clip-path="url(#clipPath2)"/>
-      <line transform="matrix(0,1,-1,0,410.0784,2119.9185)" clip-path="url(#clipPath102)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
+      <line transform="matrix(0,1,-1,0,410.0784,2119.9185)" clip-path="url(#clipPath104)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
       <line transform="matrix(0,1,-1,0,410.0784,2119.9185)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="8"/>
       <line transform="matrix(0,1,-1,0,410.0784,2119.9185)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="0"/>
       <line transform="matrix(0,1,-1,0,410.0784,2119.9185)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-125,464)" stroke-linecap="butt">
       <path fill="none" d="M507.7871 2053.3586 L563.8335 2053.3586" clip-path="url(#clipPath2)"/>
-      <line transform="matrix(1,0,0,1,563.8335,2053.3586)" clip-path="url(#clipPath103)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
-      <line transform="matrix(1,0,0,1,563.8335,2053.3586)" clip-path="url(#clipPath103)" fill="none" x1="-6" x2="-6" y1="-8" y2="8"/>
+      <line transform="matrix(1,0,0,1,563.8335,2053.3586)" clip-path="url(#clipPath105)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
+      <line transform="matrix(1,0,0,1,563.8335,2053.3586)" clip-path="url(#clipPath105)" fill="none" x1="-6" x2="-6" y1="-8" y2="8"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-125,464)" stroke-linecap="butt">
       <path fill="none" d="M942.5325 2072.7383 L942.5325 2110.9446" clip-path="url(#clipPath2)"/>
-      <line transform="matrix(0,1,-1,0,942.5325,2119.9446)" clip-path="url(#clipPath104)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
+      <line transform="matrix(0,1,-1,0,942.5325,2119.9446)" clip-path="url(#clipPath106)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
       <line transform="matrix(0,1,-1,0,942.5325,2119.9446)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="8"/>
       <line transform="matrix(0,1,-1,0,942.5325,2119.9446)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="0"/>
       <line transform="matrix(0,1,-1,0,942.5325,2119.9446)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-125,464)" stroke-linecap="butt">
       <path fill="none" d="M1040.2485 2053.3586 L1118.8999 2053.3586" clip-path="url(#clipPath2)"/>
-      <line transform="matrix(1,0,0,1,1118.8999,2053.3586)" clip-path="url(#clipPath105)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
-      <line transform="matrix(1,0,0,1,1118.8999,2053.3586)" clip-path="url(#clipPath105)" fill="none" x1="-6" x2="-6" y1="-8" y2="8"/>
+      <line transform="matrix(1,0,0,1,1118.8999,2053.3586)" clip-path="url(#clipPath107)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
+      <line transform="matrix(1,0,0,1,1118.8999,2053.3586)" clip-path="url(#clipPath107)" fill="none" x1="-6" x2="-6" y1="-8" y2="8"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-125,464)" stroke-linecap="butt">
       <path fill="none" d="M1141.3073 795.6046 L1083.5649 795.6046 L765.591 795.6046 L765.591 683.7363" clip-path="url(#clipPath2)"/>
-      <line transform="matrix(1,0,0,1,1141.3073,795.6046)" clip-path="url(#clipPath106)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
-      <line transform="matrix(1,0,0,1,1141.3073,795.6046)" clip-path="url(#clipPath106)" fill="none" x1="-6" x2="-6" y1="-8" y2="8"/>
+      <line transform="matrix(1,0,0,1,1141.3073,795.6046)" clip-path="url(#clipPath108)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
+      <line transform="matrix(1,0,0,1,1141.3073,795.6046)" clip-path="url(#clipPath108)" fill="none" x1="-6" x2="-6" y1="-8" y2="8"/>
     </g>
     <g stroke-linecap="butt" transform="matrix(1,0,0,1,-125,464)" fill="gray" text-rendering="geometricPrecision" shape-rendering="geometricPrecision" stroke-dasharray="6,2" stroke="gray" stroke-miterlimit="1.45">
       <path fill="none" d="M1243.1021 771.2299 L1243.1021 546.0117" clip-path="url(#clipPath2)"/>
       <path d="M1243.1021 779.2299 L1248.1021 767.2299 L1243.1021 770.2299 L1238.1021 767.2299 Z" clip-path="url(#clipPath2)" stroke="none"/>
       <text x="1251.5713" y="662.6425" clip-path="url(#clipPath2)" font-family="sans-serif" stroke-dasharray="none" stroke="none" xml:space="preserve">via IDs</text>
       <path fill="none" stroke-dasharray="none" d="M1243.1021 497.003 L1243.1021 403.2643 L873.0046 403.1354" clip-path="url(#clipPath2)" stroke="black"/>
-      <line transform="matrix(0,1,-1,0,1243.1021,506.003)" clip-path="url(#clipPath107)" fill="none" x1="-15" x2="-15" y1="-8" y2="8" stroke-dasharray="none" stroke="black"/>
+      <line transform="matrix(0,1,-1,0,1243.1021,506.003)" clip-path="url(#clipPath109)" fill="none" x1="-15" x2="-15" y1="-8" y2="8" stroke-dasharray="none" stroke="black"/>
       <line transform="matrix(0,1,-1,0,1243.1021,506.003)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="8" stroke-dasharray="none" stroke="black"/>
       <line transform="matrix(0,1,-1,0,1243.1021,506.003)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="0" stroke-dasharray="none" stroke="black"/>
       <line transform="matrix(0,1,-1,0,1243.1021,506.003)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="-8" stroke-dasharray="none" stroke="black"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-125,464)" stroke-linecap="butt">
       <path fill="none" d="M872.9514 403.1241 L1243.1021 403.2643 L1243.1021 301.639" clip-path="url(#clipPath2)"/>
-      <circle transform="matrix(0,-1,1,0,1243.1021,292.639)" clip-path="url(#clipPath108)" fill="white" r="5" cx="-15" cy="0" stroke="none"/>
-      <circle fill="none" r="5" clip-path="url(#clipPath108)" cx="-15" transform="matrix(0,-1,1,0,1243.1021,292.639)" cy="0"/>
+      <circle transform="matrix(0,-1,1,0,1243.1021,292.639)" clip-path="url(#clipPath110)" fill="white" r="5" cx="-15" cy="0" stroke="none"/>
+      <circle fill="none" r="5" clip-path="url(#clipPath110)" cx="-15" transform="matrix(0,-1,1,0,1243.1021,292.639)" cy="0"/>
       <line transform="matrix(0,-1,1,0,1243.1021,292.639)" clip-path="url(#clipPath89)" fill="none" x1="-10" x2="2" y1="0" y2="8"/>
       <line transform="matrix(0,-1,1,0,1243.1021,292.639)" clip-path="url(#clipPath89)" fill="none" x1="-10" x2="2" y1="0" y2="0"/>
       <line transform="matrix(0,-1,1,0,1243.1021,292.639)" clip-path="url(#clipPath89)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-125,464)" stroke-linecap="butt">
       <path fill="none" d="M646.6946 1839.2915 L646.6946 1817.0067" clip-path="url(#clipPath2)"/>
-      <circle transform="matrix(0,1,-1,0,646.6946,1848.2915)" clip-path="url(#clipPath109)" fill="white" r="5" cx="-15" cy="0" stroke="none"/>
-      <circle fill="none" r="5" clip-path="url(#clipPath109)" cx="-15" transform="matrix(0,1,-1,0,646.6946,1848.2915)" cy="0"/>
+      <circle transform="matrix(0,1,-1,0,646.6946,1848.2915)" clip-path="url(#clipPath111)" fill="white" r="5" cx="-15" cy="0" stroke="none"/>
+      <circle fill="none" r="5" clip-path="url(#clipPath111)" cx="-15" transform="matrix(0,1,-1,0,646.6946,1848.2915)" cy="0"/>
       <line transform="matrix(0,1,-1,0,646.6946,1848.2915)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="8"/>
       <line transform="matrix(0,1,-1,0,646.6946,1848.2915)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="0"/>
       <line transform="matrix(0,1,-1,0,646.6946,1848.2915)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>

--- a/assets/ERM/ERM_EntitiesWithAttributes_EN.svg
+++ b/assets/ERM/ERM_EntitiesWithAttributes_EN.svg
@@ -242,13 +242,13 @@
         <path d="M125 -464 L125 429.2172 L1520 429.2172 L1520 -464 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath55">
-        <path d="M-57.4643 -378.8341 L1048.1704 -378.8341 L1048.1704 1889.5002 L-57.4643 1889.5002 L-57.4643 -378.8341 Z"/>
+        <path d="M-56.2339 -366.0233 L1029.2372 -366.0233 L1029.2372 1860.9432 L-56.2339 1860.9432 L-56.2339 -366.0233 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath56">
-        <path d="M125 51.3004 L125 2398 L1520 2398 L1520 51.3004 Z"/>
+        <path d="M125 43.9498 L125 2398 L1520 2398 L1520 43.9498 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath57">
-        <path d="M125 -464 L125 51.3004 L1520 51.3004 L1520 -464 Z"/>
+        <path d="M125 -464 L125 43.9498 L1520 43.9498 L1520 -464 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath58">
         <path d="M-111.3304 -2234.0564 L1099.2458 -2234.0564 L1099.2458 249.5774 L-111.3304 249.5774 L-111.3304 -2234.0564 Z"/>
@@ -374,19 +374,19 @@
         <path d="M131.0209 -195.02 L131.0209 1199.98 L-2730.979 1199.98 L-2730.979 -195.02 L131.0209 -195.02 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath99">
-        <path d="M304.1516 758.0715 L-1077.5774 566.1084 L-683.7433 -2268.6648 L697.9857 -2076.7017 L304.1516 758.0715 Z"/>
+        <path d="M303.0116 759.1689 L-1078.4465 565.2652 L-680.6311 -2268.9519 L700.8269 -2075.0483 L303.0116 759.1689 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath100">
         <path d="M-12 10 L-0 10 L0 -10 L-12 -10 L-12 10 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath101">
-        <path d="M405.6499 557.4282 L-989.3501 557.4282 L-989.3501 -2304.5718 L405.6499 -2304.5718 L405.6499 557.4282 Z"/>
+        <path d="M405.6618 557.4282 L-989.3382 557.4282 L-989.3382 -2304.5718 L405.6618 -2304.5718 L405.6618 557.4282 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath102">
         <path d="M0 10 L0 -10 L-12 -10 L-12 10 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath103">
-        <path d="M-866.5147 244.3961 L-866.5147 -1150.6039 L1995.4852 -1150.6039 L1995.4854 244.3961 L-866.5147 244.3961 Z"/>
+        <path d="M-866.5137 244.3961 L-866.5137 -1150.6039 L1995.4863 -1150.6039 L1995.4863 244.3961 L-866.5137 244.3961 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath104">
         <path d="M-2583.9185 285.0784 L-2583.9185 -1109.9216 L278.0815 -1109.9216 L278.0815 285.0784 L-2583.9185 285.0784 Z"/>
@@ -401,13 +401,13 @@
         <path d="M-993.8999 -2517.3586 L401.1001 -2517.3586 L401.1001 344.6414 L-993.8999 344.6414 L-993.8999 -2517.3586 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath108">
-        <path d="M-1016.3073 -1259.6045 L378.6927 -1259.6045 L378.6927 1602.3954 L-1016.3073 1602.3955 L-1016.3073 -1259.6045 Z"/>
+        <path d="M-1016.3073 -1259.6045 L378.6927 -1259.6045 L378.6927 1602.3955 L-1016.3073 1602.3955 L-1016.3073 -1259.6045 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath109">
-        <path d="M-970.003 1118.1021 L-970.003 -276.8979 L1891.9969 -276.8979 L1891.9971 1118.1021 L-970.003 1118.1021 Z"/>
+        <path d="M-970.003 1118.1021 L-970.003 -276.8979 L1891.9971 -276.8979 L1891.9971 1118.1021 L-970.003 1118.1021 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath110">
-        <path d="M756.639 -1118.1021 L756.639 276.8979 L-2105.3608 276.8979 L-2105.3608 -1118.1021 L756.639 -1118.1021 Z"/>
+        <path d="M756.639 -1118.1021 L756.639 276.8979 L-2105.3608 276.8979 L-2105.3611 -1118.1021 L756.639 -1118.1021 Z"/>
       </clipPath>
       <clipPath clipPathUnits="userSpaceOnUse" id="clipPath111">
         <path d="M-2312.2915 521.6946 L-2312.2915 -873.3054 L549.7085 -873.3054 L549.7085 521.6946 L-2312.2915 521.6946 Z"/>
@@ -955,34 +955,35 @@
       <text x="248.0016" xml:space="preserve" y="594.2933" clip-path="url(#clipPath2)" stroke="none">Comment</text>
       <text x="248.0016" xml:space="preserve" y="608.9945" clip-path="url(#clipPath2)" stroke="none">BusinessKeys [BusinessKey]</text>
     </g>
-    <g text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1.2617,0,0,1.2617,72.5038,477.9821)" image-rendering="optimizeQuality">
-      <image x="0" y="0" clip-path="url(#clipPath55)" width="276" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAARQAAAENCAYAAADOqZoqAAAFxklEQVR4Xu3cWast&#13;&#10;1RmG0WkX++4Y+0S2JmKXYGLf54gdmv//fzI/ygUiBHTtx5tivDAurXVVD3PWPriW&#13;&#10;mZmZmZmZmZmZmZmZnX/3/Oxe4PQu73u+S0Tu2+7fHtj+tD0InM6822Pe83nfL3FJ&#13;&#10;donJPPyh7dHt8e2J7UnglOb9fmx7eB1xmbDcOiq/jMkj21Pbn7cXtpe3vwCnM+/2&#13;&#10;S9vz2511HCDmMHHrqExM5iETk3nw/Mhr2xvb29s/gNN5Z3tre317ZXtuHSeWuQ5N&#13;&#10;E67efDOZh8wRaGIyP/Du9uH26fYZcDrzbn+8vbeOuNxsz67jc8fVp5T5jy6nk7nm&#13;&#10;zMlkYjI/dnf7ZvsWOJ15t7/evtg+WMdpZa5Bc7CY7ylXB2W+ncz9ab6ZzDVnTiZ3&#13;&#10;t++3H4HT+mEdYfl8HQeJm3V89phvKVddeyYoU6O5O02d5ugzp5P5kfnB/wKn9dM6&#13;&#10;Dg5frePqMzeUZ9bxV59bBWWOOfPldz7WzP1qjkSCAud2Ccp/tve3v63j04egAL+b&#13;&#10;oAAZQQEyggJkBAXICAqQERQgIyhARlCAjKAAGUEBMr8Oyt+XoABX+mVQ5n9hICjA&#13;&#10;1QQFyAgKkBEUICMoQEZQgIygABlBATKCAmR+/S9l/dN74GqCAmQEBcgICpARFCAj&#13;&#10;KEBGUICMoAAZQQEyggJkBAXICAqQERQgIyhARlCAjKAAGUEBMoICZAQFyAgKkBEU&#13;&#10;ICMoQEZQgIygABlBATKCAmQEBcgICpARFCAjKEBGUICMoAAZQQEyggJkBAXICAqQ&#13;&#10;ERQgIyhARlCAjKAAGUEBMoICZAQFyAgKkBEUICMoQEZQgIygABlBATKCAmQEBcgI&#13;&#10;CpARFCAjKEBGUICMoAAZQQEyggJkBAXICAqQERQgIyhARlCAjKAAGUEBMoICZAQF&#13;&#10;yAgKkBEUICMoQEZQgIygABlBATKCAmQEBcgICpARFCAjKEBGUICMoAAZQQEyggJk&#13;&#10;BAXICAqQERQgIyhARlCAjKAAGUEBMoICZAQFyAgKkBEUICMoQEZQgIygABlBATKC&#13;&#10;AmQEBcgICpARFCAjKEBGUICMoAAZQQEyggJkBAXICAqQERQgIyhARlCAjKAAGUEB&#13;&#10;MoICZAQFyAgKkBEUICMoQEZQgIygABlBATKCAmQEBcgICpARFCAjKEBGUICMoAAZ&#13;&#10;QQEyggJkBAXICAqQERQgIyhARlCAjKAAGUEBMoICZAQFyAgKkBEUICMoQEZQgIyg&#13;&#10;ABlBATKCAmQEBcgICpARFCAjKEBGUICMoAAZQQEyggJkBAXICAqQERQgIyhARlCA&#13;&#10;jKAAGUEBMoICZAQFyAgKkBEUICMoQEZQgIygABlBATKCAmQEBcgICpARFCAjKEBG&#13;&#10;UICMoAAZQQEyggJkBAXICAqQERQgIyhARlCAjKAAGUEBMoICZAQFyAgKkBEUICMo&#13;&#10;QEZQgIygABlBATKCAmQEBcgICpARFCAjKEBGUICMoAAZQQEyggJkBAXICAqQERQg&#13;&#10;IyhARlCAjKAAGUEBMoICZAQFyAgKkBEUICMoQEZQgIygAJk/LChPbC9vb2+fbt8s&#13;&#10;QYGzm6B8t321vbe9toKgPLA9vr2wvbF9uN1dR7kmKsA5/bCOw8Pn27vbzXZne2jd&#13;&#10;Iij3b49uz66jUP9ax7Xn63VcfaZgwPlMTOZ08tE6bifz2eOpddxapg1X7b51FGke&#13;&#10;NNeeN7d/b59sX2xfruNHgXOYd3rMwWFuJP9cx/eT57bH1nFruTooc7SZB8wp5Znt&#13;&#10;r9vr2zvrOAZNXOZ+BZzDvNNzE5mQvLWOm8mL6/jjzBwu5pBx9aZE84A55kxU7qzj&#13;&#10;e8qE5WZ7dR0/CJzDvNM32yvruJXM546JycPr+ARy9enksktU5qQyD52PtPMDT6/j&#13;&#10;1AKcyxwc5v2ev/DOQeLBdcTk3hVtojIPu4RlfmCOP8A5zTs+N5MJybz3tz6Z/L/N&#13;&#10;gy+BAc7r8q6bmZmZmZmZmZmZmZmZmZn9lv0PAw7FgKpKIcAAAAAASUVORK5CYII=" height="269" preserveAspectRatio="none"/>
-      <rect x="208.121" y="24.5992" transform="matrix(0.7926,0,0,0.7926,-156.5355,-11.0818)" clip-path="url(#clipPath56)" fill="white" width="322.5503" image-rendering="auto" rx="4" ry="4" height="312.0234" stroke="none"/>
-      <rect x="208.121" y="24.5992" transform="matrix(0.7926,0,0,0.7926,-156.5355,-11.0818)" clip-path="url(#clipPath57)" fill="rgb(237,237,237)" width="322.5503" image-rendering="auto" rx="4" ry="4" height="312.0234" stroke="none"/>
-      <rect stroke-linecap="butt" x="208.121" y="24.5992" transform="matrix(0.7926,0,0,0.7926,-156.5355,-11.0818)" clip-path="url(#clipPath2)" fill="none" width="322.5503" image-rendering="auto" rx="4" ry="4" height="312.0234" stroke-miterlimit="1.45"/>
-      <line stroke-linecap="butt" transform="matrix(0.7926,0,0,0.7926,-156.5355,-11.0818)" clip-path="url(#clipPath2)" fill="none" x1="208.121" x2="530.6713" y1="51.3004" image-rendering="auto" y2="51.3004" stroke-miterlimit="1.45"/>
+    <g text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1.2852,0,0,1.2852,72.2694,470.3971)" image-rendering="optimizeQuality">
+      <image x="0" y="0" clip-path="url(#clipPath55)" width="271" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQ8AAAEUCAYAAAA1PrNmAAAFtklEQVR4Xu3ZWc9l&#13;&#10;RRmG4QJs5nmQMUwyioAGEVACzQz6//+P9abYCeHAhJtuk925nuQ6/PY6Wneq1reW&#13;&#10;mZmZmZmZmZmZmZmZ/f9218/uBu44l/f7lu4SjHu2P2z3/uw+4OrNu3xjnXd73vFb&#13;&#10;FpBLOObH798e2h7ZHt0eA67evMvzTj+4TkwmIpeTSN4vwzE//Pj2zPb89uL2EnD1&#13;&#10;Xtie255eJyYPrPPOz7uf98twPLnOQ17f3t7+vP0FuGrvrfMuv7W9ts7B4Il1AjIn&#13;&#10;kHz6mPvPXFWmRhOON7cPt4+3z7Z/Aldt3uNPt79vH2xvrBOQucrMt5AUj/mjKc+c&#13;&#10;OuY4MyeOCcc87Ob2zfYtcNXmPf56+2KdiLy/vbo9tc7pI11dJh5zZZkPKXMfmqvK&#13;&#10;nDhubt9vPwF3hB+379YJyEfr3DCeXeefI3P7+M2beMyxZY4v83F07kZz6phSzQP/&#13;&#10;A9wxJiBfbZ9s765zdXl4ndvHb94lHvO9Y77IzseVuSPNUUc84M4y8Zjry1xd5gPq&#13;&#10;C+vcOsQD+J/EA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jE&#13;&#10;A0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jE&#13;&#10;A0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jE&#13;&#10;A0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jE&#13;&#10;A0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jE&#13;&#10;A0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jE&#13;&#10;A0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jE&#13;&#10;A0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jE&#13;&#10;A0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jE&#13;&#10;A0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jE&#13;&#10;A0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jE&#13;&#10;A0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jE&#13;&#10;A0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jE&#13;&#10;A0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jE&#13;&#10;A0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jEA0jE&#13;&#10;A0jEA0jEA0jEA0jEA0jEA0huSzwe3V5c5wfnh79Z50G/fjhwnf69/bB9tX2yvbM9&#13;&#10;vz28fkc8bqxTn+e2t7ePt5vb9+ucPoDrN4eBuVF8sX20vbk9uz20fkc85g/nB57Z&#13;&#10;Xt8+XOfqcnOdh30HXLV5j+c28eU6N4sPtte2p7YHtntW3Pzh/dvj61xd5vTxt3WO&#13;&#10;Nv/aPgeu3hwI/rHO4eCtdb53zLfO+Wxx94qbP7yxzuljSvTS9sY63z+mUPOwvwJX&#13;&#10;a97h97d3tz+tc0h4cntwnZvH3EDS5g/n9DEFmoA8sc5daB7w8vYqcNVeWeddnnf6&#13;&#10;j+vcMiYcc2jIp47L7lonIPNjc4WZL7BzpJmHTKGA6zUHgnmX57+qc0CYd/yWhOOy&#13;&#10;Ccj82CUicxK5b50HAddr3uMx7/RcU+Ydn/f9tmx++BIT4Ppd3unbFg0zMzMzMzMz&#13;&#10;MzMzMzMzM7sl+y9UtXQhRtlXLAAAAABJRU5ErkJggg==" height="276" preserveAspectRatio="none"/>
+      <rect x="208.121" y="17.2487" transform="matrix(0.7781,0,0,0.7781,-153.4984,-4.9777)" clip-path="url(#clipPath56)" fill="white" width="322.5503" image-rendering="auto" rx="4" ry="4" height="326.7246" stroke="none"/>
+      <rect x="208.121" y="17.2487" transform="matrix(0.7781,0,0,0.7781,-153.4984,-4.9777)" clip-path="url(#clipPath57)" fill="rgb(237,237,237)" width="322.5503" image-rendering="auto" rx="4" ry="4" height="326.7246" stroke="none"/>
+      <rect stroke-linecap="butt" x="208.121" y="17.2487" transform="matrix(0.7781,0,0,0.7781,-153.4984,-4.9777)" clip-path="url(#clipPath2)" fill="none" width="322.5503" image-rendering="auto" rx="4" ry="4" height="326.7246" stroke-miterlimit="1.45"/>
+      <line stroke-linecap="butt" transform="matrix(0.7781,0,0,0.7781,-153.4984,-4.9777)" clip-path="url(#clipPath2)" fill="none" x1="208.121" x2="530.6713" y1="43.9498" image-rendering="auto" y2="43.9498" stroke-miterlimit="1.45"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" font-family="sans-serif" transform="matrix(1,0,0,1,-125,464)" stroke-linecap="butt">
-      <text x="320.0397" xml:space="preserve" y="42.6637" clip-path="url(#clipPath2)" stroke="none">ComponentMaster</text>
-      <text x="212.121" xml:space="preserve" y="69.3649" clip-path="url(#clipPath2)" stroke="none">ID*</text>
-      <text x="212.121" xml:space="preserve" y="84.066" clip-path="url(#clipPath2)" stroke="none">Designation</text>
-      <text x="212.121" xml:space="preserve" y="98.7672" clip-path="url(#clipPath2)" stroke="none">CustomerPartNumber</text>
-      <text x="212.121" xml:space="preserve" y="113.4684" clip-path="url(#clipPath2)" stroke="none">SupplierPartNumber</text>
-      <text x="212.121" xml:space="preserve" y="128.1696" clip-path="url(#clipPath2)" stroke="none">Color</text>
-      <text x="212.121" xml:space="preserve" y="142.8707" clip-path="url(#clipPath2)" stroke="none">MaterialGroup (VDA 231-106)</text>
-      <text x="212.121" xml:space="preserve" y="157.5719" clip-path="url(#clipPath2)" stroke="none">MaterialClass (VDA 231-200)</text>
-      <text x="212.121" xml:space="preserve" y="172.2731" clip-path="url(#clipPath2)" stroke="none">MaterialName</text>
-      <text x="212.121" xml:space="preserve" y="186.9742" clip-path="url(#clipPath2)" stroke="none">OemIdentifier</text>
-      <text x="212.121" xml:space="preserve" y="201.6754" clip-path="url(#clipPath2)" stroke="none">MaterialIdentifiers (VDA 231-300)</text>
-      <text x="212.121" xml:space="preserve" y="216.3766" clip-path="url(#clipPath2)" stroke="none">SurfaceIdentifiers (VDA 231-300)</text>
-      <text x="212.121" xml:space="preserve" y="231.0778" clip-path="url(#clipPath2)" stroke="none">Specifications (List of [Specification])</text>
-      <text x="212.121" xml:space="preserve" y="245.7789" clip-path="url(#clipPath2)" stroke="none">Stack [Stack]</text>
-      <text x="212.121" xml:space="preserve" y="260.4801" clip-path="url(#clipPath2)" stroke="none">SpecificationCustomizations [SpecificationCustomizations]</text>
-      <text x="212.121" xml:space="preserve" y="275.1813" clip-path="url(#clipPath2)" stroke="none">Attachment [Attachment]</text>
-      <text x="212.121" xml:space="preserve" y="289.8824" clip-path="url(#clipPath2)" stroke="none">Comment</text>
-      <text x="212.121" xml:space="preserve" y="304.5836" clip-path="url(#clipPath2)" stroke="none">BusinessKeys [BusinessKey]</text>
-      <text x="212.121" xml:space="preserve" y="319.2848" clip-path="url(#clipPath2)" stroke="none">Mass [Mass]</text>
-      <text x="212.121" xml:space="preserve" y="333.986" clip-path="url(#clipPath2)" stroke="none">NumberOfParts</text>
+      <text x="320.0397" xml:space="preserve" y="35.3131" clip-path="url(#clipPath2)" stroke="none">ComponentMaster</text>
+      <text x="212.121" xml:space="preserve" y="62.0143" clip-path="url(#clipPath2)" stroke="none">ID*</text>
+      <text x="212.121" xml:space="preserve" y="76.7155" clip-path="url(#clipPath2)" stroke="none">Designation</text>
+      <text x="212.121" xml:space="preserve" y="91.4166" clip-path="url(#clipPath2)" stroke="none">CustomerPartNumber</text>
+      <text x="212.121" xml:space="preserve" y="106.1178" clip-path="url(#clipPath2)" stroke="none">SupplierPartNumber</text>
+      <text x="212.121" xml:space="preserve" y="120.819" clip-path="url(#clipPath2)" stroke="none">Color</text>
+      <text x="212.121" xml:space="preserve" y="135.5201" clip-path="url(#clipPath2)" stroke="none">MaterialGroup (VDA 231-106)</text>
+      <text x="212.121" xml:space="preserve" y="150.2213" clip-path="url(#clipPath2)" stroke="none">MaterialClass (VDA 231-200)</text>
+      <text x="212.121" xml:space="preserve" y="164.9225" clip-path="url(#clipPath2)" stroke="none">MaterialName</text>
+      <text x="212.121" xml:space="preserve" y="179.6237" clip-path="url(#clipPath2)" stroke="none">OemIdentifier</text>
+      <text x="212.121" xml:space="preserve" y="194.3248" clip-path="url(#clipPath2)" stroke="none">MaterialIdentifiers (VDA 231-300)</text>
+      <text x="212.121" xml:space="preserve" y="209.026" clip-path="url(#clipPath2)" stroke="none">SurfaceIdentifiers (VDA 231-300)</text>
+      <text x="212.121" xml:space="preserve" y="223.7272" clip-path="url(#clipPath2)" stroke="none">Specifications (List of [Specification])</text>
+      <text x="212.121" xml:space="preserve" y="238.4283" clip-path="url(#clipPath2)" stroke="none">Stack [Stack]</text>
+      <text x="212.121" xml:space="preserve" y="253.1295" clip-path="url(#clipPath2)" stroke="none">SpecificationCustomizations [SpecificationCustomizations]</text>
+      <text x="212.121" xml:space="preserve" y="267.8307" clip-path="url(#clipPath2)" stroke="none">Attachment [Attachment]</text>
+      <text x="212.121" xml:space="preserve" y="282.5319" clip-path="url(#clipPath2)" stroke="none">Comment</text>
+      <text x="212.121" xml:space="preserve" y="297.233" clip-path="url(#clipPath2)" stroke="none">BusinessKeys [BusinessKey]</text>
+      <text x="212.121" xml:space="preserve" y="311.9342" clip-path="url(#clipPath2)" stroke="none">Mass [Mass]</text>
+      <text x="212.121" xml:space="preserve" y="326.6354" clip-path="url(#clipPath2)" stroke="none">NumberOfParts</text>
+      <text x="212.121" xml:space="preserve" y="341.3365" clip-path="url(#clipPath2)" stroke="none">NGIDPath</text>
     </g>
     <g text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1.1523,0,0,1.1523,128.2909,2574.401)" image-rendering="optimizeQuality">
       <image x="0" y="0" clip-path="url(#clipPath58)" width="276" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAARQAAACbCAYAAACj4WTAAAAEaElEQVR4Xu3a7bNW&#13;&#10;YxjG4TskRCSFRDKRXuSdiZBC4v//f1znLM/MHr7tfZoxq+OaOT621v5y/+Za99Na&#13;&#10;xhhjjDHGGGOMMcYYY4wxZv9z6m/PALt3OO/1OTz42fHcOD2eH2eA3cnZjpzznPlD&#13;&#10;XCpz2EgSkrzspfHKODdeBXYnZztn/Ox4cW1xSVgqUUlMUqqEJC97Y7w13hlXgN3J&#13;&#10;2X57XBrnx8trWyZOHJX842wmiUkefHlcGzfGrXF73AF2JWf743F9vDsurm1jyaaS&#13;&#10;BePYkyKlTNlMUqwPx93x9bg3vgN2J2f7m/H5uDmuru3LJItFFoxjbSlHt5M8LJtJ&#13;&#10;YpKX/TQe/e0XYFdyrn8e98eXa9tWLq/tbiVbyrGDkruTrDq5M8lnTjaTB+O38QTY&#13;&#10;rcfj4do2liwS2VJy7ZEvlmN99iQoqVGqlEua3JdkO0m98sI/gd36Y22Lw4/ji/HB&#13;&#10;uLC2X31OFJTcn+RiJpc1369tJcrL/vkHAPtxCEquN/LZc31tVx+1oHyyBAWeFoIC&#13;&#10;1AgKUCMoQI2gADWCAtQIClAjKECNoAA1ggLUCApQIyhAjaAANUeD8tUSFOAEBAWo&#13;&#10;ERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBag5GhT/9R44EUEBagQFqBEUoEZQgBpB&#13;&#10;AWoEBagRFKBGUIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagRFKBG&#13;&#10;UIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFqBAWo&#13;&#10;ERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFqBAWoERSgRlCAGkEB&#13;&#10;agQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQ&#13;&#10;gBpBAWoEBagRFKBGUIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagR&#13;&#10;FKBGUIAaQQFqBAWoERSgRlCAGkEBagQFqBEUoEZQgBpBAWoEBagRFKBGUIAaQQFq&#13;&#10;BAWoERSgRlCAGkEBagQFqBEUoEZQgJr/PCh3lqDA0+I/C8q58c64Pe6NR+PJ+vcf&#13;&#10;AOxHgvLr+HF8Pj4YF9YJg3J6vDzeHjfG12srVsr1+9rCAuzP4/FwfDfujvfH+fHC&#13;&#10;OkFQnhsvjYtrK9Sna9tSHqxtU8nnTyoG7EfOdWLyw9qWiJtr+0rJ9Ue+WtKGY82z&#13;&#10;48x4bVweH43Pxrdru0+5D+xOznYWh9yd3B7X1rZUnF3bknHsoBw+e7KlvL62SuVy&#13;&#10;5tbafvXJxpLAAPuQM51PnPwIk2uOq+PNtd2lZrk41ufO0ckDDlF5bVxaW1jeW9t3&#13;&#10;FbAviciV8dbaLmJfWdvdSb5YTq0TTh5wiEoemrUntUpcckmTzQXYj5zr3JckJFkk&#13;&#10;cm9SicnRycPy0HxD5QVZfyKRAfYj5zpnPEtEznsWimpMjk4efJAXAftzOOPGGGOM&#13;&#10;McYYY4wxxhhj/q/zF5L55zK+XdpCAAAAAElFTkSuQmCC" height="155" preserveAspectRatio="none"/>
@@ -1321,30 +1322,30 @@
       <text x="372.6655" xml:space="preserve" y="790.2579" clip-path="url(#clipPath2)" stroke="none">via ID</text>
     </g>
     <g stroke-linecap="butt" transform="matrix(1,0,0,1,-125,464)" fill="rgb(153,153,153)" text-rendering="geometricPrecision" shape-rendering="geometricPrecision" stroke-dasharray="6,2" stroke="rgb(153,153,153)" stroke-miterlimit="1.45">
-      <path fill="none" d="M658.2 410.5702 L588.7217 410.5702 L588.7217 316.8248 L538.6522 316.8248" clip-path="url(#clipPath2)"/>
-      <path d="M530.6522 316.8248 L542.6522 321.8248 L539.6522 316.8248 L542.6522 311.8248 Z" clip-path="url(#clipPath2)" stroke="none"/>
+      <path fill="none" d="M658.2 410.5702 L588.7217 410.5702 L588.7217 323.2426 L538.6522 323.2426" clip-path="url(#clipPath2)"/>
+      <path d="M530.6522 323.2426 L542.6522 328.2426 L539.6522 323.2426 L542.6522 318.2426 Z" clip-path="url(#clipPath2)" stroke="none"/>
       <text x="619.257" y="405.0965" clip-path="url(#clipPath2)" font-family="sans-serif" stroke-dasharray="none" stroke="none" xml:space="preserve">via ID</text>
-      <path fill="none" stroke-dasharray="none" d="M539.4892 243.7677 L539.5887 243.7573 L541.0676 243.377 L544.4137 242.1524 L547.5973 240.6187 L550.6001 238.7945 L553.4038 236.6979 L555.9901 234.3473 L558.3408 231.761 L560.4373 228.9573 L562.2615 225.9545 L563.7952 222.7709 L565.0199 219.4248 L565.9173 215.9345 L566.4692 212.3183 L566.6572 208.5946 L566.4692 204.8709 L565.9173 201.2548 L565.0198 197.7645 L563.7952 194.4184 L562.2615 191.2348 L560.4373 188.232 L558.3407 185.4283 L555.9901 182.842 L553.4038 180.4914 L550.6001 178.3948 L547.5973 176.5706 L544.4137 175.0369 L541.0676 173.8123 L537.5773 172.9148 L533.9612 172.3629 L530.6738 172.1969" clip-path="url(#clipPath2)" stroke="black"/>
-      <circle transform="matrix(-0.9905,0.1376,-0.1376,-0.9905,530.5748,245.0061)" clip-path="url(#clipPath99)" fill="white" r="5" stroke-dasharray="none" cx="-15" cy="0" stroke="none"/>
-      <circle transform="matrix(-0.9905,0.1376,-0.1376,-0.9905,530.5748,245.0061)" clip-path="url(#clipPath99)" fill="none" r="5" stroke-dasharray="none" cx="-15" cy="0" stroke="black"/>
-      <line transform="matrix(-0.9905,0.1376,-0.1376,-0.9905,530.5748,245.0061)" clip-path="url(#clipPath100)" fill="none" x1="-10" x2="2" y1="0" y2="8" stroke-dasharray="none" stroke="black"/>
-      <line transform="matrix(-0.9905,0.1376,-0.1376,-0.9905,530.5748,245.0061)" clip-path="url(#clipPath100)" fill="none" x1="-10" x2="2" y1="0" y2="0" stroke-dasharray="none" stroke="black"/>
-      <line transform="matrix(-0.9905,0.1376,-0.1376,-0.9905,530.5748,245.0061)" clip-path="url(#clipPath100)" fill="none" x1="-10" x2="2" y1="0" y2="-8" stroke-dasharray="none" stroke="black"/>
+      <path fill="none" stroke-dasharray="none" d="M539.5065 244.43 L539.6059 244.4185 L541.6972 243.8403 L545.0211 242.555 L548.177 240.9637 L551.1468 239.0851 L553.9125 236.9378 L556.4563 234.5404 L558.7601 231.9115 L560.8059 229.0699 L562.5758 226.034 L564.0518 222.8227 L565.2159 219.4544 L566.0502 215.9479 L566.5366 212.3218 L566.6572 208.5947 L566.4018 204.8743 L565.7845 201.2682 L564.8239 197.7942 L563.5386 194.4702 L561.9473 191.3144 L560.0687 188.3446 L557.9214 185.5788 L555.524 183.0351 L552.8951 180.7313 L550.0535 178.6855 L547.0176 176.9156 L543.8063 175.4396 L540.438 174.2755 L536.9315 173.4412 L533.3054 172.9548 L530.6556 172.869" clip-path="url(#clipPath2)" stroke="black"/>
+      <circle transform="matrix(-0.9903,0.139,-0.139,-0.9903,530.5939,245.681)" clip-path="url(#clipPath99)" fill="white" r="5" stroke-dasharray="none" cx="-15" cy="0" stroke="none"/>
+      <circle transform="matrix(-0.9903,0.139,-0.139,-0.9903,530.5939,245.681)" clip-path="url(#clipPath99)" fill="none" r="5" stroke-dasharray="none" cx="-15" cy="0" stroke="black"/>
+      <line transform="matrix(-0.9903,0.139,-0.139,-0.9903,530.5939,245.681)" clip-path="url(#clipPath100)" fill="none" x1="-10" x2="2" y1="0" y2="8" stroke-dasharray="none" stroke="black"/>
+      <line transform="matrix(-0.9903,0.139,-0.139,-0.9903,530.5939,245.681)" clip-path="url(#clipPath100)" fill="none" x1="-10" x2="2" y1="0" y2="0" stroke-dasharray="none" stroke="black"/>
+      <line transform="matrix(-0.9903,0.139,-0.139,-0.9903,530.5939,245.681)" clip-path="url(#clipPath100)" fill="none" x1="-10" x2="2" y1="0" y2="-8" stroke-dasharray="none" stroke="black"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" font-family="sans-serif" transform="matrix(1,0,0,1,-125,464)" stroke-linecap="butt">
-      <text x="536.8058" xml:space="preserve" y="262.1939" clip-path="url(#clipPath2)" stroke="none">SubComponents</text>
-      <path fill="none" d="M539.6499 93.4282 L662.8221 93.4282" clip-path="url(#clipPath2)"/>
-      <line transform="matrix(-1,0,0,-1,530.6499,93.4282)" clip-path="url(#clipPath101)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
-      <line transform="matrix(-1,0,0,-1,530.6499,93.4282)" clip-path="url(#clipPath102)" fill="none" x1="-10" x2="2" y1="0" y2="8"/>
-      <line transform="matrix(-1,0,0,-1,530.6499,93.4282)" clip-path="url(#clipPath102)" fill="none" x1="-10" x2="2" y1="0" y2="0"/>
-      <line transform="matrix(-1,0,0,-1,530.6499,93.4282)" clip-path="url(#clipPath102)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>
+      <text x="537.1702" xml:space="preserve" y="261.7848" clip-path="url(#clipPath2)" stroke="none">SubComponents</text>
+      <path fill="none" d="M539.6618 93.4282 L662.8221 93.4282" clip-path="url(#clipPath2)"/>
+      <line transform="matrix(-1,0,0,-1,530.6618,93.4282)" clip-path="url(#clipPath101)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
+      <line transform="matrix(-1,0,0,-1,530.6618,93.4282)" clip-path="url(#clipPath102)" fill="none" x1="-10" x2="2" y1="0" y2="8"/>
+      <line transform="matrix(-1,0,0,-1,530.6618,93.4282)" clip-path="url(#clipPath102)" fill="none" x1="-10" x2="2" y1="0" y2="0"/>
+      <line transform="matrix(-1,0,0,-1,530.6618,93.4282)" clip-path="url(#clipPath102)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-125,464)" stroke-linecap="butt">
-      <path fill="none" d="M369.3961 336.6156 L369.3961 393.5147" clip-path="url(#clipPath2)"/>
-      <line transform="matrix(0,1,-1,0,369.3961,402.5147)" clip-path="url(#clipPath103)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
-      <line transform="matrix(0,1,-1,0,369.3961,402.5147)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="8"/>
-      <line transform="matrix(0,1,-1,0,369.3961,402.5147)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="0"/>
-      <line transform="matrix(0,1,-1,0,369.3961,402.5147)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>
+      <path fill="none" d="M369.3961 343.9579 L369.3961 393.5137" clip-path="url(#clipPath2)"/>
+      <line transform="matrix(0,1,-1,0,369.3961,402.5137)" clip-path="url(#clipPath103)" fill="none" x1="-15" x2="-15" y1="-8" y2="8"/>
+      <line transform="matrix(0,1,-1,0,369.3961,402.5137)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="8"/>
+      <line transform="matrix(0,1,-1,0,369.3961,402.5137)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="0"/>
+      <line transform="matrix(0,1,-1,0,369.3961,402.5137)" clip-path="url(#clipPath68)" fill="none" x1="-10" x2="2" y1="0" y2="-8"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,-125,464)" stroke-linecap="butt">
       <path fill="none" d="M410.0784 2072.7241 L410.0784 2110.9185" clip-path="url(#clipPath2)"/>

--- a/main/VDA_231-301_Schema_Generic.json
+++ b/main/VDA_231-301_Schema_Generic.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://vda231-301.github.io/schemas/generic/VDA_231-301_generic_v2.0.0.schema.json",
+  "$id": "https://vda231-301.github.io/schemas/generic/VDA_231-301_generic_v2.1.0.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "VDA 231-301 TestingProject JSON schema",
   "type": "object",
@@ -1265,7 +1265,7 @@
           "type": "string"
         },
         "Designation": {
-          "type": "string"
+          "$ref": "#/$defs/Generic.RestrictedString"
         },
         "Instances": {
           "items": {
@@ -1279,6 +1279,10 @@
             "$ref": "#/$defs/Generic.ComponentMaster"
           },
           "type": "array"
+        },
+        "NGIDPath": {
+          "type": "string",
+          "description": "A Siemens JT Next Generation Identifier (NGID) path locating this component's occurrence within the source CAD assembly structure, per the 'NGID Identifiers' specification (e.g. $$NGID<chain>=\"__CAD_INST_UID\"\\0AssemblyName.asm;version;instanceId:\\0PartName.asm;version;instanceId:\\0\\0)."
         },
         "CustomerPartNumber": {
           "$ref": "#/$defs/Generic.RestrictedString",

--- a/main/VDA_231-301_Schema_Generic.json
+++ b/main/VDA_231-301_Schema_Generic.json
@@ -14,7 +14,7 @@
       "type": "string"
     },
     "_schemaVersion": {
-      "const": "2.0.0",
+      "const": "2.1.0",
       "description": "The generic schema version on which the structure of the testing project is based on."
     },
     "Title": {
@@ -1264,12 +1264,21 @@
           "const": "ComponentMaster",
           "type": "string"
         },
+        "Designation": {
+          "type": "string"
+        },
         "Instances": {
           "items": {
             "$ref": "#/$defs/Generic.ComponentInstance"
           },
           "type": "array",
           "description": "A list of instances of this component."
+        },
+        "SubComponents": {
+          "items": {
+            "$ref": "#/$defs/Generic.ComponentMaster"
+          },
+          "type": "array"
         },
         "CustomerPartNumber": {
           "$ref": "#/$defs/Generic.RestrictedString",


### PR DESCRIPTION
closes #14 
closes #19 

## Summary

Please provide a short and clear summary of the changes introduced by this pull request.

---

## Type of Change

Please indicate what kind of change this pull request introduces:

- [x] Documentation / editorial change
- [x] Clarification or correction
- [ ] Subschema schema change
- [ ] Example or sample data update
- [x] Proposal / preparatory work
- [ ] Other

---

## Motivation and Context

See #19 
---

## Description of Changes

- Two properties were added to `ComponentMaster`:
    - `Designation` - A name field for the (sub) component
    - `SubComponents` nested `ComponentMaster`s
- ERM Diagrams updated to include these changes

---

## Subschema and Version Context

- Subschema affected:
- Subschema version / branch:
- Generic schema context (if applicable): Version bumped to v2.1.0 (unreleased)

---

## Impact and Compatibility

-Fully backwards compatible

---

## Checklist

Please confirm the following:

- [x] I have checked existing issues and pull requests to avoid duplicates.
- [x] This change is within the scope of this repository.
- [x] This pull request does not claim to constitute an official VDA release or approval.
- [x] I understand that acceptance on GitHub does not replace the formal VDA review and release process.

---

## Additional Notes

Any additional information that may be helpful for reviewers.
